### PR TITLE
deploy(apollo-rhworker): add preCommand and postCommand values for cronjobs

### DIFF
--- a/deploy/apollo/apollo-rhworker/Chart.yaml
+++ b/deploy/apollo/apollo-rhworker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
+++ b/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
@@ -30,9 +30,11 @@ spec:
             imagePullPolicy: IfNotPresent
             command: ["/bin/bash", "-c"]
             args:
-            - |
-              trap 'curl --max-time 2 -s -f -XPOST http://127.0.0.1:15020/quitquitquit' EXIT
-              while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done
-              echo "Ready!"
-              tctl wf run --tq v2-rhworker --wt PollRHAdvisoriesWorkflow
+              {{- range $cmd := $.Values.cron.preCommand }}
+              - {{ $cmd }}
+              {{- end }}
+              - tctl wf run --tq v2-rhworker --wt PollRHAdvisoriesWorkflow
+              {{- range $cmd := $.Values.cron.postCommand }}
+              - {{ $cmd }}
+              {{- end }}
 {{- end }}

--- a/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
+++ b/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
@@ -19,6 +19,7 @@ spec:
           serviceAccountName: {{ include "apollo-rhworker.serviceAccountName" . }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | indent 8 }}
+          activeDeadlineSeconds: 300
           containers:
           - name: {{ .Chart.Name }}-poll-rh-advisories-workflow
             image: temporalio/admin-tools:1.10.5

--- a/deploy/apollo/apollo-rhworker/values.yaml
+++ b/deploy/apollo/apollo-rhworker/values.yaml
@@ -83,6 +83,12 @@ autoscaling:
 cron:
   enabled: true
   schedule: "*/15 * * * *"
+  preCommand:
+    - trap 'curl --max-time 2 -s -f -XPOST http://127.0.0.1:15020/quitquitquit' EXIT
+    - while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done
+    - echo "Ready!"
+  postCommand:
+    - echo "Complete!"
 
 nodeSelector: {}
 


### PR DESCRIPTION

We don't want to assume a user will be running this with Istio as the RESF is, so we don't always need to kill the istio proxy in this manner

This change moves the existing trap/curl command to terminate the istio proxy into values.yaml for our deployment allowing it to be overwritten for others needs