### PR TITLE
fix: preCommand and postCommand injected improperly

### DIFF
--- a/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
+++ b/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
@@ -31,11 +31,12 @@ spec:
             imagePullPolicy: IfNotPresent
             command: ["/bin/bash", "-c"]
             args:
+            - |
               {{- range $cmd := $.Values.cron.preCommand }}
-              - {{ $cmd }}
+              {{ $cmd }}
               {{- end }}
-              - tctl wf run --tq v2-rhworker --wt PollRHAdvisoriesWorkflow
+              tctl wf run --tq v2-rhworker --wt PollRHAdvisoriesWorkflow
               {{- range $cmd := $.Values.cron.postCommand }}
-              - {{ $cmd }}
+              {{ $cmd }}
               {{- end }}
 {{- end }}


### PR DESCRIPTION
these need to be strings we pass as a single object to bash -c, rather than multiple discrete commands.