### PR TITLE
updateinfo.xml: fix duplicate description for each update

### DIFF
--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -90,9 +90,6 @@ async def get_updateinfo(
         # Add title
         ET.SubElement(update, "title").text = advisory.synopsis
 
-        # Add description
-        ET.SubElement(update, "description").text = advisory.description
-
         # Add time
         time_format = "%Y-%m-%d %H:%M:%S"
         issued = ET.SubElement(update, "issued")


### PR DESCRIPTION
Each update only needs the description once.

Fixes: https://github.com/resf/distro-tools/issues/32

**NOTE**: this is 100% completely untested.

The description is being added down further https://github.com/resf/distro-tools/blob/main/apollo/server/routes/api_updateinfo.py#L125 and it seems to make sense to have it next to the summary... but ordering does not matter in the updateinfo xml.