### PR TITLE
Advisory module handling

### DIFF
--- a/apollo/rpmworker/repomd.py
+++ b/apollo/rpmworker/repomd.py
@@ -8,13 +8,6 @@ from os import path
 import aiohttp
 import yaml
 
-import logging
-module_logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="[%(name)s][%(asctime)s][%(levelname)s][%(funcName)s %(lineno)d] - %(message)s"
-)
-
 NVRA_RE = re.compile(
     r"^(\S+)-([\w~%.+^]+)-(\w+(?:\.[\w~%+]+)+?)(?:\.(\w+))?(?:\.rpm)?$"
 )
@@ -40,8 +33,6 @@ def clean_nvra_pkg(matching_pkg: ET.Element) -> str:
 
     cleaned = f"{name}-{version}-{clean_release}.{arch}"
     raw = f"{name}-{version}-{release}.{arch}"
-    # module_logger.debug(f"cleaned: {cleaned}")
-    # module_logger.debug(f"raw: {raw}")
     if ".module+" in release:
         cleaned = f"module.{cleaned}"
         raw = f"module.{raw}"
@@ -60,8 +51,6 @@ def clean_nvra(nvra_raw: str) -> str:
 
     cleaned = f"{name}-{version}-{clean_release}.{arch}"
     raw = f"{name}-{version}-{release}.{arch}"
-    # module_logger.debug(f"cleaned: {cleaned}")
-    # module_logger.debug(f"raw: {raw}")
     if ".module+" in release:
         cleaned = f"module.{cleaned}"
         raw = f"module.{raw}"
@@ -72,7 +61,6 @@ def clean_nvra(nvra_raw: str) -> str:
 async def download_xml(
     url: str, gz: bool = False, xz: bool = False
 ) -> ET.Element:
-    module_logger.debug(f"Downloading repomd: {url}")
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as resp:
             if resp.status != 200:
@@ -128,7 +116,6 @@ async def get_data_from_repomd(
                 path.join(parsed_url.path, "../..", location.attrib["href"])
             )
             data_url = parsed_url._replace(path=new_path).geturl()
-            module_logger.debug(f"data_url: {data_url}")
             if is_yaml:
                 return await download_yaml(
                     data_url,

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -540,45 +540,41 @@ async def process_repomd(
             module_logger.debug(f"No matching package found for {advisory.name}, moving on.")
             continue
         
-        module_re = re.compile(r"([0-9.a-z]{1,})\.module\+(.*)\+(.*)\+([a-z0-9]{8})(.*)")
+        
+        def strip_module_info(pkg: str):
+            module_re = re.compile(r"([0-9.a-z]{1,})\.module\+(.*)\+(.*)\+([a-z0-9]{8})(.*)")
+            pkg_nvra = nvra_re.search(pkg)
+            pkg_release = pkg_nvra.group(3)
+            if ".module+" in pkg_release:
+                module_info = module_re.search(pkg_release)
+                release_major = module_info.group(1)  # example: '65'
+                dist_info = module_info.group(2)  # example: 'el8.10.0'
+                release_minor = module_info.group(5)  # example: '.1'
+                dist_info_parts = dist_info.split(".")
+                if len(dist_info_parts) > 2:
+                    dist_compare = ".".join(dist_info_parts[:-1])
+                else:
+                    dist_compare = dist_info
+                return f"{release_major}.{dist_compare}.{release_minor}"
+            return pkg_release  # return the original release if no module info found
 
+        def compare_rocky_red_hat(rocky_nvr: str, red_hat_nvr: str) -> bool:
+            rocky_release = strip_module_info(rocky_nvr)
+            red_hat_release = strip_module_info(red_hat_nvr)
+            module_logger.debug(f"Comparing Rocky release '{rocky_release}' with Red Hat release '{red_hat_release}'")
+            return rocky_release == red_hat_release
+        
         did_match_any = False
-        module_logger.debug(f"nvra_alias: {json.dumps(nvra_alias, indent=2)}")
-        module_logger.debug(f"clean_advisory_nvras: {json.dumps(clean_advisory_nvras, indent=2)}")
+        # module_logger.debug(f"nvra_alias: {json.dumps(nvra_alias, indent=2)}")
+        # module_logger.debug(f"clean_advisory_nvras: {json.dumps(clean_advisory_nvras, indent=2)}")
         for nevra, raw_advisory_nvra in clean_advisory_nvras.items():
             module_logger.debug(f"advisory_nevra: {nevra}, raw_advisory_nvra: {raw_advisory_nvra}")
-            advisory_nvra = nvra_re.search(raw_advisory_nvra)
-            advisory_pkg_release = advisory_nvra.group(3)
-            if ".module+" in advisory_pkg_release:
-                advisory_module_info = module_re.search(advisory_pkg_release)
-                advisory_release_major = advisory_module_info.group(1)  # example: '65'
-                advisory_dist_info = advisory_module_info.group(3)  # example: 'el8.10.0'
-                advisory_release_minor = advisory_module_info.group(5)  # example: '.1'
-                advisory_dist_info_parts = advisory_dist_info.split(".")
             if nevra in raw_pkg_nvras:
                 for pkg in raw_pkg_nvras[nevra]:
                     cleaned, raw = repomd.clean_nvra_pkg(pkg)
                     module_logger.debug(f"rocky_raw: {raw}")
-                    pkg_nvra = nvra_re.search(raw)
-                    release = pkg_nvra.group(3)
-                    if ".module+" in release: # example: '65.module+el8.10.0+1840+b070a976.1'
-                        rocky_module_info = module_re.search(release)
-                        rocky_release_major = rocky_module_info.group(1)  # example: '65'
-                        rocky_dist_info = rocky_module_info.group(3) # example: 'el8.10.0'
-                        rocky_release_minor = rocky_module_info.group(5) # example: '.1'
-                        rocky_dist_info_parts = rocky_dist_info.split(".")
-                        if len(rocky_dist_info_parts) > 2:
-                            placeholder_comp = ".".join(rocky_dist_info_parts[:-1])
-                        else:
-                            placeholder_comp = rocky_dist_info
-
-                        if len(advisory_dist_info_parts) > 2:
-                            placeholder_advisory_comp = ".".join(advisory_dist_info_parts[:-1])
-                        else:
-                            placeholder_advisory_comp = advisory_dist_info
-                        if f"{rocky_release_major}.{placeholder_comp}.{rocky_release_minor}" != f"{advisory_release_major}.{placeholder_advisory_comp}.{advisory_release_minor}":
-                            module_logger.debug(f"Skipping {raw} due to placeholder mismatch")
-                            continue
+                    if not compare_rocky_red_hat(raw, raw_advisory_nvra):
+                        continue
                     pkg.set("repo_name", rpm_repomd.repo_name)
                     pkg.set("mirror_id", str(mirror.id))
                     check_pkgs.add(pkg)
@@ -590,26 +586,8 @@ async def process_repomd(
                 for pkg in raw_pkg_nvras.get(nvra_alias[nevra], []):
                     cleaned, raw = repomd.clean_nvra_pkg(pkg)
                     module_logger.debug(f"rocky_raw: {raw}")
-                    pkg_nvra = nvra_re.search(raw)
-                    release = pkg_nvra.group(3)
-                    if ".module+" in release: # example: '65.module+el8.10.0+1840+b070a976.1'
-                        rocky_module_info = module_re.search(release)
-                        rocky_release_major = rocky_module_info.group(1)  # example: '65'
-                        rocky_dist_info = rocky_module_info.group(3) # example: 'el8.10.0'
-                        rocky_release_minor = rocky_module_info.group(5) # example: '.1'
-                        rocky_dist_info_parts = rocky_dist_info.split(".")
-                        if len(rocky_dist_info_parts) > 2:
-                            placeholder_comp = ".".join(rocky_dist_info_parts[:-1])
-                        else:
-                            placeholder_comp = rocky_dist_info
-
-                        if len(advisory_dist_info_parts) > 2:
-                            placeholder_advisory_comp = ".".join(advisory_dist_info_parts[:-1])
-                        else:
-                            placeholder_advisory_comp = advisory_dist_info
-                        if f"{rocky_release_major}.{placeholder_comp}.{rocky_release_minor}" != f"{advisory_release_major}.{placeholder_advisory_comp}.{advisory_release_minor}":
-                            module_logger.debug(f"Skipping {raw} due to placeholder mismatch")
-                            continue
+                    if not compare_rocky_red_hat(raw, raw_advisory_nvra):
+                        continue
                     pkg.set("repo_name", rpm_repomd.repo_name)
                     pkg.set("mirror_id", str(mirror.id))
                     check_pkgs.add(pkg)


### PR DESCRIPTION
# Changes
The level changes introduced in this PR are to properly add all matching module streams to the cloned Rocky advisories. Previously the "cleaned" versions of package nvrs would remove the module stream information which led to the cloned advisories not containing all appropriate module streams.
###  `repomd.py`
* Return both the "cleaned" and "raw" versions of a package name from the `clean_nvra_pkg1 and `clean_vra` functions.

### `rh_matcher_activities.py`
* `clone_advisory()`: Add some code comments
* `process_repomd()`: 
  * add the raw package versions to the `raw_package_map` dictionary with the key being the "cleaned" nvr and the value being a list of all matching "raw" nvrs.
  *  Use the "raw" package name as the value for the `nvra_alias` dictionary.

# Testing
In my local setup for Apollo I compared the advisories generated with main and the advisories generated with these changes in place. There were no Rocky advisories removed and advisories with modules generally saw an increase in the number of linked packages. Having spot checked a number of them I saw that we now included multiple module streams which led to the increased number of associated packages.

```
(.venv) [mrthorn@rocky-mobile distro-tools]$ python3 -m pytest apollo/tests --ignore node_modules --ignore .venv --ignore-glob "bazel-*" -v
/home/mrthorn/resf/distro-tools/.venv/lib64/python3.9/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================= test session starts ========================================================
platform linux -- Python 3.9.21, pytest-8.3.5, pluggy-1.5.0 -- /home/mrthorn/resf/distro-tools/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/mrthorn/resf/distro-tools
plugins: mock-3.14.0, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 11 items

apollo/tests/publishing_tools/test_apollo_tree.py::test_scan_path_valid_structure PASSED                                     [  9%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_scan_path_multiple_formats PASSED                                    [ 18%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_scan_path_valid_structure_arch_first PASSED                          [ 27%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_fetch_updateinfo_from_apollo_live SKIPPED (Skipping test_fetch_u...) [ 36%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_fetch_updateinfo_from_apollo_live_no_updateinfo SKIPPED (Skippin...) [ 45%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_fetch_updateinfo_from_apollo_mock PASSED                             [ 54%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_gzip_updateinfo PASSED                                               [ 63%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_write_updateinfo_to_file PASSED                                      [ 72%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_update_repomd_xml PASSED                                             [ 81%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_run_apollo_tree PASSED                                               [ 90%]
apollo/tests/publishing_tools/test_apollo_tree.py::test_run_apollo_tree_arch_in_product PASSED                               [100%]

=================================================== 9 passed, 2 skipped in 0.08s ===================================================
```