### PR TITLE
CSAFv2 Ingestion Proof of Concept

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,8 @@ jobs:
         python-version: '3.11'
 
     - name: Setup Bazel
-      uses: bazelbuild/setup-bazelisk@v2
+      uses: bazelbuild/setup-bazelisk@v3
+      continue-on-error: true
 
     - name: Setup
       run: ./build/scripts/setup.bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,17 +3,35 @@ name: Lint and test
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
-
   lint_test:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        
+    - name: Setup Bazel
+      uses: bazelbuild/setup-bazelisk@v2
+        
     - name: Setup
       run: ./build/scripts/setup.bash
+      
     - name: Lint
       run: ./build/scripts/pylint.bash
-    - name: Test
+      
+    - name: Unit Tests
+      run: |
+        bazel test //apollo/tests:test_rpm_helpers --test_output=all
+        bazel test //apollo/tests:test_rhcsaf --test_output=all
+        bazel test //apollo/tests:test_csaf_processing --test_output=all
+      
+    - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "errata-csaf-initiative" ]
 
 jobs:
   lint_test:
@@ -17,21 +17,21 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-        
+
     - name: Setup Bazel
       uses: bazelbuild/setup-bazelisk@v2
-        
+
     - name: Setup
       run: ./build/scripts/setup.bash
-      
+
     - name: Lint
       run: ./build/scripts/pylint.bash
-      
+
     - name: Unit Tests
       run: |
         bazel test //apollo/tests:test_rpm_helpers --test_output=all
         bazel test //apollo/tests:test_rhcsaf --test_output=all
         bazel test //apollo/tests:test_csaf_processing --test_output=all
-      
+
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/apollo/rhcsaf/BUILD.bazel
+++ b/apollo/rhcsaf/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+
+# gazelle:exclude example.py
+
+py_library(
+    name = "rhcsaf_lib",
+    srcs = ["__init__.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+      "//apollo/rpm_helpers:rpm_helpers_lib",
+      "@pypi_aiohttp//:pkg",
+    ],
+)

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -1,0 +1,128 @@
+import pathlib
+import json
+import os
+import re
+
+from common.info import Info
+from common.logger import Logger
+from apollo.rpm_helpers import parse_nevra
+
+# Initialize Info before Logger for this module
+
+logger = Logger()
+# logger = logging.getLogger(__name__)
+# # Add a StreamHandler to output logs to the console
+# console_handler = logging.StreamHandler()
+# console_handler.setLevel(logging.DEBUG)
+# formatter = logging.Formatter('%(levelname)s - %(message)s')
+# console_handler.setFormatter(formatter)
+# logger.addHandler(console_handler)
+
+
+def red_hat_advisory_scraper(filename: pathlib.Path):
+    logger.info(f"Parsing CSAF document{filename}")
+    with open(filename, "r") as f:
+        csaf = json.load(f)
+    
+    # At the time of writing there are ~254 advisories that do not have any vulnerabilities.
+    if not csaf.get("vulnerabilities"):
+        logger.warning("No vulnerabilities found in CSAF document %s", filename)
+        return None
+
+    # red_hat_advisories table values
+    red_hat_issued_at = csaf["document"]["tracking"]["initial_release_date"] # "2025-02-24T03:42:46+00:00"
+    red_hat_updated_at = csaf["document"]["tracking"]["current_release_date"] # "2025-04-17T12:08:56+00:00"
+    name = csaf["document"]["tracking"]["id"] # "RHSA-2025:1234"
+    red_hat_synopsis = csaf["document"]["title"] # "Red Hat Bug Fix Advisory: Red Hat Quay v3.13.4 bug fix release"
+    red_hat_description = None
+    for item in csaf["document"]["notes"]:
+        if item["category"] == "general":
+            red_hat_description = item["text"]
+    kind_lookup = {"RHSA": "Security", "RHBA": "Bug Fix", "RHEA": "Enhancement"}
+    kind = kind_lookup[name.split("-")[0]] # "RHSA-2025:1234" --> "Security"
+    severity = csaf["document"]["aggregate_severity"]["text"] # "Important"
+
+    # To maintain consistency with the existing database, we need to replace the
+    # "Red Hat [KIND] Advisory:" prefixes with the severity level.
+    red_hat_synopsis = red_hat_synopsis.replace("Red Hat Bug Fix Advisory: ", f"{severity}:")
+    red_hat_synopsis = red_hat_synopsis.replace("Red Hat Security Advisory:", f"{severity}:")
+    red_hat_synopsis = red_hat_synopsis.replace("Red Hat Enhancement Advisory: ", f"{severity}:")
+
+    topic = None
+    for item in csaf["document"]["notes"]:
+        if item["category"] == "summary":
+            topic = item["text"]
+
+    # red_hat_advisory_packages table values
+    red_hat_fixed_packages = set()
+    red_hat_cve_set = set()
+    red_hat_bugzilla_set = set()
+    product_id_suffix_list = (
+        ".aarch64",
+        ".i386",
+        ".i686",
+        ".noarch",
+        ".ppc",
+        ".ppc64",
+        ".ppc64le",
+        ".s390",
+        ".s390x",
+        ".src",
+        ".x86_64"
+    ) # TODO: find a better way to filter product IDs. This is a workaround for the fact that
+    # the product IDs in the CSAF documents also contain artifacts like container images
+    # and we only are interested in RPMs.
+    for vulnerability in csaf["vulnerabilities"]:
+        for product_id in vulnerability["product_status"]["fixed"]:
+            if product_id.endswith(product_id_suffix_list):
+                # These IDs are in the format product:package_nevra
+                # ie- AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.aarch64"
+                split_on_colon = product_id.split(":")
+                product = split_on_colon[0]
+                package_nevra = ":".join(split_on_colon[-2:])
+                red_hat_fixed_packages.add(package_nevra)
+
+        # red_hat_advisory_cves table values. Many older advisories do not have CVEs and so we need to handle that.
+        cve_id = vulnerability.get("cve", None)
+        cve_cvss3_scoring_vector = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("vectorString", None)
+        cve_cvss3_base_score = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("baseScore", None)
+        cve_cwe = vulnerability.get("cwe", {}).get("id", None)
+        red_hat_cve_set.add((cve_id, cve_cvss3_scoring_vector, cve_cvss3_base_score, cve_cwe))
+
+        # red_hat_advisory_bugzilla_bugs table values
+        for bug in vulnerability["references"]:
+            if bug["category"] == "external" and "bugzilla" in bug["url"]:
+                bugzilla_id = bug["url"].split("?")[-1].split("=")[-1] # "https://bugzilla.redhat.com/show_bug.cgi?id=123456" --> "123456"
+                red_hat_bugzilla_set.add(bugzilla_id)
+
+    # red_hat_advisory_affected_products table values
+    red_hat_affected_products = set()
+    for package_nevra in red_hat_fixed_packages:
+        product_info = parse_nevra(package_nevra)
+        if product_info:
+            # Create a tuple of values to add to the set
+            product_tuple = (
+                "Red Hat Enterprise Linux",
+                f"Red Hat Enterprise Linux {product_info['dist_major']}",
+                product_info["dist_major"],
+                product_info["dist_minor"],
+                product_info["arch"]
+            )
+            red_hat_affected_products.add(product_tuple)
+
+    return {
+        "red_hat_issued_at": str(red_hat_issued_at),
+        "red_hat_updated_at": str(red_hat_updated_at),
+        "name": str(name),
+        "red_hat_synopsis": str(red_hat_synopsis),
+        "red_hat_description": str(red_hat_description),
+        "kind": str(kind),
+        "severity": str(severity),
+        "topic": str(topic),
+        "red_hat_fixed_packages": list(red_hat_fixed_packages),
+        "red_hat_cve_list": list(red_hat_cve_set),
+        "red_hat_bugzilla_list": list(red_hat_bugzilla_set),
+        "red_hat_affected_products": list(red_hat_affected_products),
+    }
+
+

--- a/apollo/rhworker/BUILD.bazel
+++ b/apollo/rhworker/BUILD.bazel
@@ -28,6 +28,7 @@ py_library(
     deps = [
         "//apollo/db:db_lib",
         "//apollo/rherrata:rherrata_lib",
+        "//apollo/rhcsaf:rhcsaf_lib",
         "//common:common_lib",
         "@pypi_aiohttp//:pkg",
         "@pypi_temporalio//:pkg",

--- a/apollo/rhworker/__main__.py
+++ b/apollo/rhworker/__main__.py
@@ -8,14 +8,15 @@ import asyncio
 from temporalio.worker import Worker
 import click
 
-from common.database import Database
 from common.info import Info
 from common.logger import Logger
+Info("apollorhworker", "apollo2") # TODO: Dive into the logging for Apollo to see if we can clean this up at all. Currently this hack is required to get the RHWorker Temporal worker to start correctly. This has something to do with the way the Info class is initialized in common.info. It seems to be a singleton, and it is initialized before the logger is set up. This causes issues when the logger tries to log messages before it is fully configured. By calling Info("apollorhworker", "apollo2"), we ensure that the Info class is initialized with the correct parameters for this worker, allowing it to log messages correctly.
+from common.database import Database
 from common.temporal import Temporal
 
 from apollo.rhworker.temporal import TASK_QUEUE
-from apollo.rhworker.poll_rh_workflow import PollRHAdvisoriesWorkflow
-from apollo.rhworker.poll_rh_activities import get_last_indexed_date, get_rh_advisories
+from apollo.rhworker.poll_rh_workflow import PollRHAdvisoriesWorkflow, PollRHCSAFAdvisoriesWorkflow
+from apollo.rhworker.poll_rh_activities import get_last_indexed_date, get_rh_advisories, process_csaf_files
 
 
 async def run():
@@ -30,10 +31,12 @@ async def run():
         task_queue=TASK_QUEUE,
         workflows=[
             PollRHAdvisoriesWorkflow,
+            PollRHCSAFAdvisoriesWorkflow,
         ],
         activities=[
             get_last_indexed_date,
             get_rh_advisories,
+            process_csaf_files,
         ]
     )
 
@@ -42,7 +45,6 @@ async def run():
 
 @click.command()
 def main():
-    Info("apollorhworker", "apollo2")
     Logger().info("Starting apollo-rhworker")
     asyncio.run(run())
 

--- a/apollo/rhworker/poll_rh_activities.py
+++ b/apollo/rhworker/poll_rh_activities.py
@@ -1,8 +1,9 @@
-import datetime
+from datetime import datetime
 import re
 import bz2
 from typing import Optional
 from xml.etree import ElementTree as ET
+import os
 
 import aiohttp
 from temporalio import activity
@@ -15,6 +16,7 @@ from apollo.db import (
     RedHatAdvisoryCVE,
 )
 from apollo.rherrata import API
+from apollo.rhcsaf import red_hat_advisory_scraper
 
 from common.logger import Logger
 
@@ -22,8 +24,36 @@ OVAL_NS = {"": "http://oval.mitre.org/XMLSchema/oval-definitions-5"}
 bz_re = re.compile(r"BZ#([0-9]+)")
 
 
-def parse_red_hat_date(rhdate: str) -> datetime.datetime:
-    return datetime.datetime.fromisoformat(rhdate.removesuffix("Z"))
+def parse_red_hat_date(rhdate: str) -> datetime:
+    return datetime.fromisoformat(rhdate.removesuffix("Z"))
+
+
+def standardize_datetime_string(dt_str: str) -> str:
+    """Standardize datetime string format by ensuring proper formatting of timezone"""
+    # Remove any colons from timezone part
+    if '+' in dt_str:
+        base, tz = dt_str.split('+')
+        tz = tz.replace(':', '')
+        return f"{base}+{tz}"
+    return dt_str
+
+
+def parse_datetime(dt_str: str) -> datetime:
+    """Parse datetime string with various formats"""
+    formats = [
+        "%Y-%m-%dT%H:%M:%S%z",  # 2025-04-17T12:08:56+0000
+        "%Y-%m-%dT%H%M%S%z",    # 2025-04-17T143259+0000
+        "%Y-%m-%d %H:%M:%S%z"   # 2025-04-17 14:32:59+0000
+    ]
+
+    dt_str = standardize_datetime_string(dt_str)
+
+    for fmt in formats:
+        try:
+            return datetime.strptime(dt_str, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"Unable to parse datetime string: {dt_str}")
 
 
 @activity.defn
@@ -233,3 +263,189 @@ async def get_rh_advisories(from_timestamp: str = None) -> None:
             logger.info("Processed advisory %s", advisory.id)
 
     return None
+
+async def process_csaf_file(filepath: str) -> Optional[RedHatAdvisory]:
+    """Process a CSAF file and insert/update the data in the database"""
+    logger = Logger()
+    logger.info("INFO logging is enabled")
+    logger.debug("DEBUG logging is enabled")
+    data = red_hat_advisory_scraper(filepath)
+    if not data:
+        logger.warning(f"No data returned from scraper for {filepath}")
+        return None
+
+    try:
+        async with in_transaction():
+            # Check if advisory already exists
+            logger.info(f"Starting transaction for {filepath}")
+            advisory = await RedHatAdvisory.get_or_none(name=data["name"])
+
+            if advisory:
+                logger.info(f"Advisory {advisory.name} already exists, checking for updates")
+                # Update existing advisory if fields are different
+                updates = {}
+                if parse_datetime(str(advisory.red_hat_issued_at)) != parse_datetime(data["red_hat_issued_at"]):
+                    logger.info(f"date from DB: {advisory.red_hat_issued_at} != date from CSAF: {data['red_hat_issued_at']}")
+                    updates["red_hat_issued_at"] = parse_datetime(data["red_hat_issued_at"])
+
+                # TODO: Update DB to track Red Hat updated at date
+                # if advisory.red_hat_updated_at is None:
+                #     logger.info(f"advisory.red_hat_updated_at is None")
+                # elif parse_datetime(str(advisory.red_hat_updated_at)) != parse_datetime(data["red_hat_updated_at"]):
+                #     logger.info(f"date from DB: {advisory.red_hat_updated_at} != date from CSAF: {data['red_hat_updated_at']}")
+                #     updates["red_hat_updated_at"] = parse_datetime(data["red_hat_updated_at"])
+
+                if advisory.synopsis != data["red_hat_synopsis"]:
+                    updates["synopsis"] = data["red_hat_synopsis"]
+                if advisory.description != data["red_hat_description"]:
+                    updates["description"] = data["red_hat_description"]
+                if advisory.kind != data["kind"]:
+                    updates["kind"] = data["kind"]
+                if advisory.severity != data["severity"]:
+                    updates["severity"] = data["severity"]
+                if advisory.topic != data["topic"]:
+                    updates["topic"] = data["topic"]
+
+                if updates:
+                    updates["updated_at"] = datetime.now()
+                for field, value in updates.items():
+                    setattr(advisory, field, value)
+                    await advisory.save()
+            else:
+                # Create new advisory
+                logger.info(f"Creating new advisory {data['name']}")
+                advisory = await RedHatAdvisory.create(
+                    red_hat_issued_at=datetime.fromisoformat(data["red_hat_issued_at"]),
+                    # TODO: Update DB to track Red Hat updated at date
+                    # red_hat_updated_at=datetime.fromisoformat(data["red_hat_updated_at"]),
+                    name=data["name"],
+                    synopsis=data["red_hat_synopsis"],
+                    description=data["red_hat_description"],
+                    kind=data["kind"],
+                    severity=data["severity"],
+                    topic=data["topic"],
+                )
+
+            # Handle packages
+            logger.info(f"Processing packages for advisory {advisory.name}")
+            existing_packages = set(p.nevra for p in await RedHatAdvisoryPackage.filter(
+                red_hat_advisory_id=advisory.id).all())
+            new_packages = set(data["red_hat_fixed_packages"]) - existing_packages
+            if new_packages:
+                logger.info(f"New packages for advisory {advisory.name}: {new_packages}")
+                await RedHatAdvisoryPackage.bulk_create([
+                    RedHatAdvisoryPackage(
+                        red_hat_advisory_id=advisory.id,
+                        nevra=nevra
+                    ) for nevra in new_packages
+                ], ignore_conflicts=True)
+
+            # Handle CVEs
+            logger.info(f"Processing CVEs for advisory {advisory.name}")
+            existing_cves = set(c.cve for c in await RedHatAdvisoryCVE.filter(
+                red_hat_advisory_id=advisory.id).all())
+            logger.debug(f"Existing CVEs: {existing_cves}")
+            for cve_data in data["red_hat_cve_list"]:
+                logger.debug(f"Processing CVE data: {cve_data}")
+                cve_id, vector, score, cwe = cve_data
+                if cve_id and cve_id not in existing_cves:
+                    logger.info(f"New CVE for advisory {advisory.name}: {cve_id}")
+                    await RedHatAdvisoryCVE.create(
+                        red_hat_advisory_id=advisory.id,
+                        cve=cve_id,
+                        cvss3_scoring_vector=vector,
+                        cvss3_base_score=str(score) if score else None,
+                        cwe=cwe if cwe else None,
+                    )
+                else:
+                    logger.debug(f"No new CVE found for advisory {advisory.name}")
+
+            # Handle Bugzilla tickets
+            logger.info(f"Processing Bugzilla bugs for advisory {advisory.name}")
+            try:
+                existing_bugs = set(b.bugzilla_bug_id for b in await RedHatAdvisoryBugzillaBug.filter(
+                    red_hat_advisory_id=advisory.id).all())
+                logger.debug(f"Existing Bugzilla bugs: {existing_bugs}")
+                new_bugs = set(data["red_hat_bugzilla_list"]) - existing_bugs
+
+                if new_bugs:
+                    logger.info(f"New Bugzilla bugs for advisory {advisory.name}: {new_bugs}")
+                    await RedHatAdvisoryBugzillaBug.bulk_create([
+                        RedHatAdvisoryBugzillaBug(
+                            red_hat_advisory_id=advisory.id,
+                            bugzilla_bug_id=bug_id,
+                            description=""  # No description available in CSAF data
+                        ) for bug_id in new_bugs
+                    ], ignore_conflicts=True)
+                else:
+                    logger.debug(f"No new Bugzilla bugs found for advisory {advisory.name}")
+            except Exception as e:
+                logger.error(f"Error processing Bugzilla bugs for advisory {advisory.name}: {str(e)}")
+                raise
+
+            # Handle affected products
+            logger.info(f"Processing affected products for advisory {advisory.name}")
+            existing_products = set()
+            for prod in await RedHatAdvisoryAffectedProduct.filter(red_hat_advisory_id=advisory.id).all():
+                existing_products.add((prod.variant, prod.name, prod.major_version, prod.minor_version, prod.arch))
+
+            new_products = []
+            for product_data in data["red_hat_affected_products"]:
+                if product_data not in existing_products:
+                    variant, name, major, minor, arch = product_data
+                    new_products.append(
+                        RedHatAdvisoryAffectedProduct(
+                            red_hat_advisory_id=advisory.id,
+                            variant=variant,
+                            name=name,
+                            major_version=major,
+                            minor_version=minor,
+                            arch=arch
+                        )
+                    )
+            if new_products:
+                logger.info(f"Adding {len(new_products)} new affected products for advisory {advisory.name}")
+                await RedHatAdvisoryAffectedProduct.bulk_create(new_products, ignore_conflicts=True)
+    except Exception as e:
+        logger.error(f"Error in transaction: {str(e)}")
+        raise
+
+        return advisory
+
+
+@activity.defn
+async def process_csaf_files() -> dict:
+    logger = Logger()
+    logger.info("Starting CSAF file processing")
+    csaf_dir = os.environ.get("RHCSAF_DIR")
+    # TODO: Develop a way to get the latest CSAF files.
+    #       Options:
+    #       1. Pull latest files and store on disk
+    #       2. Read diff from Red Hat and stream new files without disk storage
+    #       3. Implement incremental updates based on Red Hat's change tracking
+    processed = 0
+    errors = 0
+    try:  # Add error handling
+        for root, _, files in os.walk(csaf_dir):
+            logger.info(f"Scanning directory: {root}")  # Add this line
+            for file in files:
+                if file.endswith(".json"):
+                    filepath = os.path.join(root, file)
+                    logger.info(f"Processing file: {filepath}")  # Add this line
+                    try:
+                        advisory = await process_csaf_file(filepath)
+                        if advisory:
+                            logger.info(f"Successfully processed {filepath}")
+                            processed += 1
+                        else:
+                            logger.warning(f"Skipped {filepath} - no data returned")
+                    except Exception as e:
+                        logger.error(f"Error processing {filepath}: {str(e)}")
+                        errors += 1
+                        continue
+    except Exception as e:
+        logger.error(f"Fatal error during processing: {str(e)}")
+        raise
+
+    logger.info(f"Processing complete. Processed: {processed}, Errors: {errors}")
+    return {"processed": processed, "errors": errors}

--- a/apollo/rhworker/poll_rh_activities.py
+++ b/apollo/rhworker/poll_rh_activities.py
@@ -308,9 +308,9 @@ async def process_csaf_file(filepath: str) -> Optional[RedHatAdvisory]:
 
                 if updates:
                     updates["updated_at"] = datetime.now()
-                for field, value in updates.items():
-                    setattr(advisory, field, value)
-                    await advisory.save()
+                    for field, value in updates.items():
+                        setattr(advisory, field, value)
+                        await advisory.save()
             else:
                 # Create new advisory
                 logger.info(f"Creating new advisory {data['name']}")
@@ -417,7 +417,8 @@ async def process_csaf_file(filepath: str) -> Optional[RedHatAdvisory]:
 async def process_csaf_files() -> dict:
     logger = Logger()
     logger.info("Starting CSAF file processing")
-    csaf_dir = os.environ.get("RHCSAF_DIR")
+    csaf_dir = "/home/mrthorn/redhat_advisories"
+    # csaf_dir = os.environ.get("RHCSAF_DIR")
     # TODO: Develop a way to get the latest CSAF files.
     #       Options:
     #       1. Pull latest files and store on disk

--- a/apollo/rhworker/poll_rh_workflow.py
+++ b/apollo/rhworker/poll_rh_workflow.py
@@ -22,3 +22,18 @@ class PollRHAdvisoriesWorkflow:
         )
 
         return None
+
+
+@workflow.defn
+class PollRHCSAFAdvisoriesWorkflow:
+    """
+    Polls Red Hat CSAFv2 Advisories for new errata.
+    """
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.execute_activity(
+            "process_csaf_files",
+            start_to_close_timeout=datetime.timedelta(hours=2),
+        )
+
+        return None

--- a/apollo/rpm_helpers/BUILD.bazel
+++ b/apollo/rpm_helpers/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+
+# gazelle:exclude example.py
+
+py_library(
+    name = "rpm_helpers_lib",
+    srcs = ["__init__.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+      "@pypi_aiohttp//:pkg",
+    ],
+)

--- a/apollo/rpm_helpers/__init__.py
+++ b/apollo/rpm_helpers/__init__.py
@@ -1,0 +1,81 @@
+import re
+import json
+
+def parse_dist_version(release: str) -> dict:
+    """
+    Extract Red Hat major and minor versions from release string.
+    
+    Examples:
+    - "4.module+el8.10.0+22411+85254afd" -> {"major": 8, "minor": 10}
+    - "427.55.1.el9_4" -> {"major": 9, "minor": 4}
+    - "1.el8" -> {"major": 8, "minor": None}
+    """
+    # Pattern matches:
+    # 1. module+el{major}.{minor} - for module packages
+    # 2. el{major}_{minor} - for regular packages with minor version
+    # 3. el{major} - for regular packages without minor version
+    pattern = r"""
+        (?:module\+)?     # Optional module prefix
+        (?:el|rhel)       # Distribution identifier
+        (\d+)             # Major version (capture group 1)
+        (?:[\._]          # Separator (dot or underscore)
+        (\d+))?          # Optional minor version (capture group 2)
+    """
+    
+    match = re.search(pattern, release, re.VERBOSE)
+    if not match:
+        return {"major": None, "minor": None}
+    
+    major = int(match.group(1))
+    minor = int(match.group(2)) if match.group(2) else None
+    
+    return {
+        "major": major,
+        "minor": minor
+    }
+
+def parse_nevra(filename):
+    # Strip off optional .rpm extension
+    if filename.endswith('.rpm'):
+        filename = filename[:-4]
+
+    # Split off arch
+    try:
+        rest, arch = filename.rsplit('.', 1)
+    except ValueError:
+        raise ValueError("Missing architecture in NEVRA string")
+
+    # Split off release
+    try:
+        nvr, release = rest.rsplit('-', 1)
+    except ValueError:
+        raise ValueError("Missing release in NEVRA string")
+
+    # Split off version
+    try:
+        name_version, version = nvr.rsplit('-', 1)
+    except ValueError:
+        raise ValueError("Missing version in NEVRA string")
+
+    # Split epoch if present (it will be in the version part)
+    if ':' in version:
+        epoch, version = version.split(':', 1)
+    else:
+        epoch = 0
+
+    name = name_version
+    dist_version = parse_dist_version(release)
+    if dist_version["major"] is None:
+        raise ValueError("Invalid distribution version in NEVRA string")
+    major = dist_version["major"]
+    minor = dist_version["minor"]
+    return {
+        "raw": filename,
+        "name": name,
+        "epoch": epoch,
+        "version": version,
+        "release": release,
+        "arch": arch,
+        "dist_major": major,
+        "dist_minor": minor,
+    }

--- a/apollo/rpm_helpers/__init__.py
+++ b/apollo/rpm_helpers/__init__.py
@@ -34,14 +34,49 @@ def parse_dist_version(release: str) -> dict:
         "minor": minor
     }
 
-def parse_nevra(filename):
+def parse_nevra(nevra_str: str) -> dict:
+    """
+    Parse a NEVRA (Name-Epoch-Version-Release-Architecture) string from an RPM nevra_str.
+
+    The function extracts the following components from the given nevra_str:
+        - name: Package name
+        - epoch: Epoch (defaults to 0 if not present)
+        - version: Version string
+        - release: Release string
+        - arch: Architecture
+        - dist_major: Major distribution version (parsed from release)
+        - dist_minor: Minor distribution version (parsed from release)
+        - raw: The original nevra_str with optional '.rpm' extension removed
+
+    Args:
+        nevra_str (str): The RPM nevra_str or NEVRA string to parse.
+
+    Returns:
+        dict: A dictionary containing the parsed NEVRA components.
+
+    Raises:
+        ValueError: If the nevra_str is missing required NEVRA components or has an invalid distribution version.
+
+    Example:
+        parse_nevra("bash-0:5.1.8-6.el9.x86_64.rpm")
+        {
+            'raw': 'bash-0:5.1.8-6.el9.x86_64',
+            'name': 'bash',
+            'epoch': '0',
+            'version': '5.1.8',
+            'release': '6.el9',
+            'arch': 'x86_64',
+            'dist_major': 9,
+            'dist_minor': None
+        }
+    """
     # Strip off optional .rpm extension
-    if filename.endswith('.rpm'):
-        filename = filename[:-4]
+    if nevra_str.endswith('.rpm'):
+        nevra_str = nevra_str[:-4]
 
     # Split off arch
     try:
-        rest, arch = filename.rsplit('.', 1)
+        rest, arch = nevra_str.rsplit('.', 1)
     except ValueError:
         raise ValueError("Missing architecture in NEVRA string")
 
@@ -70,7 +105,7 @@ def parse_nevra(filename):
     major = dist_version["major"]
     minor = dist_version["minor"]
     return {
-        "raw": filename,
+        "raw": nevra_str,
         "name": name,
         "epoch": epoch,
         "version": version,

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+py_test(
+    name = "test_rpm_helpers",
+    srcs = ["test_rpm_helpers.py"],
+    deps = [
+        "//apollo/rpm_helpers:rpm_helpers_lib",
+    ],
+)
+
+py_test(
+    name = "test_csaf_processing",
+    srcs = ["test_csaf_processing.py"],
+    deps = [
+        "//apollo/rhworker:rhworker_lib",
+        "//apollo/db:db_lib",
+        "//common:common_lib",  # Add common library dependency
+    ],
+)
+
+py_test(
+    name = "test_rhcsaf",
+    srcs = ["test_rhcsaf.py"],
+    deps = [
+        "//apollo/rhcsaf:rhcsaf_lib",
+        "//apollo/rpm_helpers:rpm_helpers_lib",
+        "//common:common_lib",
+    ],
+)

--- a/apollo/tests/publishing_tools/data/updateinfo__test__1.xml
+++ b/apollo/tests/publishing_tools/data/updateinfo__test__1.xml
@@ -2,25 +2,6 @@
   <update from="releng@rockylinux.org" status="final" type="security" version="2">
     <id>RLSA-2022:1821</id>
     <title>Moderate: python27:2.7 security update</title>
-    <description>Python is an interpreted, interactive, object-oriented programming language that supports modules, classes, exceptions, high-level dynamic data types, and dynamic typing. The python27 packages provide a stable release of Python 2.7 with a number of additional utilities and database connectors for MySQL and PostgreSQL.
-
-Security Fix(es):
-
-* python: urllib: Regular expression DoS in AbstractBasicAuthHandler (CVE-2021-3733)
-
-* python: ftplib should not use the host from the PASV response (CVE-2021-4189)
-
-* python-lxml: HTML Cleaner allows crafted and SVG embedded scripts to pass through (CVE-2021-43818)
-
-* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)
-
-* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)
-
-For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
-
-Additional Changes:
-
-For detailed information on changes in this release, see the Rocky Linux 8.6 Release Notes linked from the References section.</description>
     <issued>2022-05-10 08:02:50</issued>
     <updated>2023-02-02 13:41:28</updated>
     <rights>Copyright 2023 Rocky Enterprise Software Foundation</rights>
@@ -69,17 +50,6 @@ For detailed information on changes in this release, see the Rocky Linux 8.6 Rel
   <update from="releng@rockylinux.org" status="final" type="security" version="2">
     <id>RLSA-2022:7593</id>
     <title>Moderate: python27:2.7 security update</title>
-    <description>Python is an interpreted, interactive, object-oriented programming language that supports modules, classes, exceptions, high-level dynamic data types, and dynamic typing.
-
-Security Fix(es):
-
-* python: mailcap: findmatch() function does not sanitize the second argument (CVE-2015-20107).
-
-For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
-
-Additional Changes:
-
-For detailed information on changes in this release, see the Rocky Linux 8.7 Release Notes linked from the References section.</description>
     <issued>2022-11-08 06:23:47</issued>
     <updated>2023-02-02 13:52:34</updated>
     <rights>Copyright 2023 Rocky Enterprise Software Foundation</rights>

--- a/apollo/tests/test_csaf_processing.py
+++ b/apollo/tests/test_csaf_processing.py
@@ -1,0 +1,188 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+import json
+import pathlib
+
+# Mock the logger before importing the target module
+mock_logger = MagicMock()
+with patch('common.logger.Logger') as mock_logger_class:
+    mock_logger_class.return_value = mock_logger
+    from apollo.rhworker.poll_rh_activities import process_csaf_file
+    from apollo.db import (RedHatAdvisory, RedHatAdvisoryPackage, 
+                         RedHatAdvisoryCVE, RedHatAdvisoryBugzillaBug, 
+                         RedHatAdvisoryAffectedProduct)
+
+class TestCsafProcessing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Mock Info class
+        with patch('common.info.Info') as mock_info:
+            mock_info_instance = MagicMock()
+            mock_info_instance.name = "test_csaf_processing"
+            mock_info.return_value = mock_info_instance
+
+    def setUp(self):
+        # Create sample CSAF data matching schema requirements
+        self.sample_csaf = {
+            "document": {
+                "tracking": {
+                    "initial_release_date": "2025-01-01T00:00:00+00:00",
+                    "current_release_date": "2025-01-02T00:00:00+00:00",
+                    "id": "RHSA-2025:0001"
+                },
+                "title": "Important: Test Advisory",
+                "notes": [
+                    {
+                        "category": "general",
+                        "text": "Test Description"
+                    },
+                    {
+                        "category": "summary",
+                        "text": "Test Topic"
+                    }
+                ],
+                "aggregate_severity": {
+                    "text": "Important"
+                }
+            },
+            "vulnerabilities": [{
+                "product_status": {
+                    "fixed": [
+                        "package-1.0-1.el8.x86_64",
+                        "package-1.0-1.el8.i686"
+                    ]
+                },
+                "cve": "CVE-2025-0001",
+                "scores": [{
+                    "cvss_v3": {
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                        "baseScore": 9.8
+                    }
+                }],
+                "cwe": {
+                    "id": "CWE-79"
+                },
+                "references": [
+                    {
+                        "category": "external",
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=12345"
+                    },
+                    {
+                        "category": "external",
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=67890"
+                    }
+                ]
+            }]
+        }
+        
+        # Create a temporary file with the sample data
+        self.test_file = pathlib.Path("test_csaf.json")
+        with open(self.test_file, "w") as f:
+            json.dump(self.sample_csaf, f)
+
+    def tearDown(self):
+        # Clean up temporary file
+        self.test_file.unlink(missing_ok=True)
+
+    @patch('apollo.db.RedHatAdvisory')
+    @patch('apollo.db.RedHatAdvisoryPackage')
+    @patch('apollo.db.RedHatAdvisoryCVE')
+    @patch('apollo.db.RedHatAdvisoryBugzillaBug')
+    @patch('apollo.db.RedHatAdvisoryAffectedProduct')
+    async def test_new_advisory_creation(self, mock_affected, mock_bz, mock_cve, 
+                                       mock_pkg, mock_advisory):
+        # Set up mocks with schema-compliant data
+        mock_advisory.get_or_none.return_value = None
+        mock_advisory.create.return_value = MagicMock(
+            id=1,
+            created_at=datetime.now(),
+            updated_at=None,
+            red_hat_issued_at=datetime(2025, 1, 1),
+            red_hat_updated_at=datetime(2025, 1, 2),
+            name="RHSA-2025:0001",
+            synopsis="Important: Test Advisory",
+            description="Test Description",
+            kind="SecurityFix",
+            severity="Important",
+            topic="Test Topic"
+        )
+        
+        result = await process_csaf_file(str(self.test_file))
+        
+        # Verify advisory creation with schema fields
+        mock_advisory.create.assert_called_once()
+        create_args = mock_advisory.create.call_args[1]
+        self.assertEqual(create_args["name"], "RHSA-2025:0001")
+        self.assertEqual(create_args["synopsis"], "Important: Test Advisory")
+        self.assertEqual(create_args["description"], "Test Description")
+        self.assertEqual(create_args["kind"], "SecurityFix")
+        self.assertEqual(create_args["severity"], "Important")
+        self.assertEqual(create_args["topic"], "Test Topic")
+        
+        # Verify package creation with schema fields
+        mock_pkg.bulk_create.assert_called_once()
+        pkg_args = mock_pkg.bulk_create.call_args[0][0]
+        for pkg in pkg_args:
+            self.assertIn("red_hat_advisory_id", pkg)
+            self.assertIn("nevra", pkg)
+        
+        # Verify CVE creation with schema fields
+        mock_cve.bulk_create.assert_called_once()
+        cve_args = mock_cve.bulk_create.call_args[0][0]
+        for cve in cve_args:
+            self.assertIn("red_hat_advisory_id", cve)
+            self.assertIn("cve", cve)
+            self.assertIn("cvss3_scoring_vector", cve)
+            self.assertIn("cvss3_base_score", cve)
+            self.assertIn("cwe", cve)
+        
+        # Verify Bugzilla creation with schema fields
+        mock_bz.bulk_create.assert_called_once()
+        bz_args = mock_bz.bulk_create.call_args[0][0]
+        for bz in bz_args:
+            self.assertIn("red_hat_advisory_id", bz)
+            self.assertIn("bugzilla", bz)
+        
+        # Verify affected products creation with schema fields
+        mock_affected.bulk_create.assert_called_once()
+        affected_args = mock_affected.bulk_create.call_args[0][0]
+        for affected in affected_args:
+            self.assertIn("red_hat_advisory_id", affected)
+            self.assertIn("variant", affected)
+            self.assertIn("arch", affected)
+            self.assertIn("major_version", affected)
+            self.assertIn("minor_version", affected)
+
+    @patch('apollo.db.RedHatAdvisory')
+    async def test_advisory_update(self, mock_advisory):
+        # Test updating an existing advisory with schema-compliant data
+        existing = MagicMock(
+            id=1,
+            created_at=datetime(2024, 1, 1),
+            updated_at=None,
+            red_hat_issued_at=datetime(2024, 1, 1),
+            red_hat_updated_at=datetime(2024, 1, 1),
+            name="RHSA-2025:0001",
+            synopsis="Moderate: Old Synopsis",
+            description="Old Description",
+            kind="SecurityFix",
+            severity="Moderate",
+            topic="Old Topic"
+        )
+        mock_advisory.get_or_none.return_value = existing
+        
+        result = await process_csaf_file(str(self.test_file))
+        
+        self.assertEqual(existing.severity, "Important")
+        self.assertEqual(existing.synopsis, "Important: Test Advisory")
+        self.assertEqual(existing.description, "Test Description")
+        self.assertEqual(existing.topic, "Test Topic")
+
+    async def test_invalid_csaf_file(self):
+        # Test handling of invalid CSAF file
+        with open("invalid_csaf.json", "w") as f:
+            f.write("invalid json")
+            
+        with self.assertRaises(Exception):
+            await process_csaf_file("invalid_csaf.json")

--- a/apollo/tests/test_rhcsaf.py
+++ b/apollo/tests/test_rhcsaf.py
@@ -1,0 +1,140 @@
+import unittest
+from pathlib import Path
+import json
+from unittest.mock import patch, MagicMock
+
+# Mock logger before importing module
+mock_logger = MagicMock()
+with patch('common.logger.Logger') as mock_logger_class:
+    mock_logger_class.return_value = mock_logger
+    from apollo.rhcsaf import red_hat_advisory_scraper
+
+class TestRedHatAdvisoryScraper(unittest.TestCase):
+    def setUp(self):
+        # Create sample CSAF data
+        self.sample_csaf = {
+            "document": {
+                "tracking": {
+                    "initial_release_date": "2025-02-24T03:42:46+00:00",
+                    "current_release_date": "2025-04-17T12:08:56+00:00",
+                    "id": "RHSA-2025:1234"
+                },
+                "title": "Red Hat Security Advisory: Important: package security update",
+                "aggregate_severity": {
+                    "text": "Important"
+                },
+                "notes": [
+                    {
+                        "category": "general",
+                        "text": "Test description"
+                    },
+                    {
+                        "category": "summary",
+                        "text": "Test topic"
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2025-1234",
+                    "product_status": {
+                        "fixed": [
+                            "AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.x86_64",
+                            "AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.src"
+                        ]
+                    },
+                    "scores": [{
+                        "cvss_v3": {
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                            "baseScore": 9.8
+                        }
+                    }],
+                    "cwe": {
+                        "id": "CWE-79"
+                    },
+                    "references": [
+                        {
+                            "category": "external",
+                            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=123456"
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        # Write test CSAF file
+        self.test_file = Path("test_csaf.json")
+        with open(self.test_file, "w") as f:
+            json.dump(self.sample_csaf, f)
+
+    def tearDown(self):
+        # Clean up test file
+        self.test_file.unlink(missing_ok=True)
+
+    def test_parse_security_advisory(self):
+        """Test parsing a security advisory"""
+        result = red_hat_advisory_scraper(self.test_file)
+        
+        self.assertEqual(result["name"], "RHSA-2025:1234")
+        self.assertEqual(result["kind"], "Security")
+        self.assertEqual(result["severity"], "Important")
+        self.assertEqual(result["red_hat_description"], "Test description")
+        self.assertEqual(result["topic"], "Test topic")
+        
+        # Check fixed packages
+        self.assertIn("rsync-0:3.2.3-19.el9_4.1.x86_64", result["red_hat_fixed_packages"])
+        self.assertIn("rsync-0:3.2.3-19.el9_4.1.src", result["red_hat_fixed_packages"])
+        
+        # Check CVE information
+        self.assertIn(
+            ("CVE-2025-1234", 
+             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+             9.8,
+             "CWE-79"),
+            result["red_hat_cve_list"]
+        )
+        
+        # Check Bugzilla information
+        self.assertIn("123456", result["red_hat_bugzilla_list"])
+        
+        # Check affected products
+        self.assertIn(
+            ("Red Hat Enterprise Linux", 
+             "Red Hat Enterprise Linux 9",
+             9,
+             4,
+             "x86_64"),
+            result["red_hat_affected_products"]
+        )
+
+    def test_bugfix_advisory(self):
+        """Test parsing a bug fix advisory"""
+        self.sample_csaf["document"]["tracking"]["id"] = "RHBA-2025:1234"
+        self.sample_csaf["document"]["title"] = "Red Hat Bug Fix Advisory: package update"
+        
+        with open(self.test_file, "w") as f:
+            json.dump(self.sample_csaf, f)
+            
+        result = red_hat_advisory_scraper(self.test_file)
+        self.assertEqual(result["kind"], "Bug Fix")
+
+    def test_enhancement_advisory(self):
+        """Test parsing an enhancement advisory"""
+        self.sample_csaf["document"]["tracking"]["id"] = "RHEA-2025:1234"
+        self.sample_csaf["document"]["title"] = "Red Hat Enhancement Advisory: package update"
+        
+        with open(self.test_file, "w") as f:
+            json.dump(self.sample_csaf, f)
+            
+        result = red_hat_advisory_scraper(self.test_file)
+        self.assertEqual(result["kind"], "Enhancement")
+
+    def test_no_vulnerabilities(self):
+        """Test handling of CSAF file with no vulnerabilities"""
+        self.sample_csaf.pop("vulnerabilities")
+        
+        with open(self.test_file, "w") as f:
+            json.dump(self.sample_csaf, f)
+            
+        result = red_hat_advisory_scraper(self.test_file)
+        self.assertIsNone(result)

--- a/apollo/tests/test_rpm_helpers.py
+++ b/apollo/tests/test_rpm_helpers.py
@@ -1,0 +1,91 @@
+import unittest
+from apollo.rpm_helpers import parse_nevra, parse_dist_version
+
+class TestRpmHelpers(unittest.TestCase):
+    def test_parse_dist_version(self):
+        test_cases = [
+            # Regular packages
+            ("1.el8", {"major": 8, "minor": None}),
+            ("427.55.1.el9_4", {"major": 9, "minor": 4}),
+            ("2.el8_7", {"major": 8, "minor": 7}),
+            
+            # Module packages
+            ("4.module+el8.10.0+22411+85254afd", {"major": 8, "minor": 10}),
+            ("6.module+el9.2.0+18751+b6bd9bab", {"major": 9, "minor": 2}),
+            
+            # Invalid cases
+            ("1.fc38", {"major": None, "minor": None}),
+            ("noversion", {"major": None, "minor": None}),
+        ]
+        
+        for release, expected in test_cases:
+            with self.subTest(release=release):
+                result = parse_dist_version(release)
+                self.assertEqual(result, expected)
+
+    def test_parse_nevra(self):
+        test_cases = [
+            # Regular package
+            (
+                "openssh-9.0p1-15.el9.x86_64",
+                {
+                    "raw": "openssh-9.0p1-15.el9.x86_64",
+                    "name": "openssh",
+                    "epoch": 0,
+                    "version": "9.0p1",
+                    "release": "15.el9",
+                    "arch": "x86_64",
+                    "dist_major": 9,
+                    "dist_minor": None,
+                }
+            ),
+            # Package with epoch
+            (
+                "python-requests-2:2.14.2-2.el8.noarch",
+                {
+                    "raw": "python-requests-2:2.14.2-2.el8.noarch",
+                    "name": "python-requests",
+                    "epoch": "2",
+                    "version": "2.14.2",
+                    "release": "2.el8",
+                    "arch": "noarch",
+                    "dist_major": 8,
+                    "dist_minor": None,
+                }
+            ),
+            # Module package
+            (
+                "perl-App-cpanminus-1.7044-6.module+el8.10.0+22411+409a293e.noarch",
+                {
+                    "raw": "perl-App-cpanminus-1.7044-6.module+el8.10.0+22411+409a293e.noarch",
+                    "name": "perl-App-cpanminus",
+                    "epoch": 0,
+                    "version": "1.7044",
+                    "release": "6.module+el8.10.0+22411+409a293e",
+                    "arch": "noarch",
+                    "dist_major": 8,
+                    "dist_minor": 10,
+                }
+            ),
+        ]
+        
+        for nevra, expected in test_cases:
+            with self.subTest(nevra=nevra):
+                result = parse_nevra(nevra)
+                self.assertEqual(result, expected)
+
+    def test_parse_nevra_errors(self):
+        invalid_nevras = [
+            "package-1.0", # Missing arch
+            "package.x86_64", # Missing version and release
+            "package-1.0.x86_64", # Missing release
+            "package-1.fc38.x86_64", # Invalid distribution
+        ]
+        
+        for nevra in invalid_nevras:
+            with self.subTest(nevra=nevra):
+                with self.assertRaises(ValueError):
+                    parse_nevra(nevra)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# CSAF Advisory Ingestion System

## Overview
This PR implements a new CSAF-based advisory ingestion system replacing the HYDRA API for Red Hat errata information, along with test coverage. The overall project plan can be found [here](https://docs.google.com/document/d/1qoYYLcJ4m2dgDLmnUTIQ3lF1KSc5QeKAssfhsVRz3v4/edit?usp=sharing).

## Implementation Details

### Core Features
* New `rhcsaf` library for CSAF advisory processing
* New `rpm_helpers` library for RPM NEVRA parsing
* CSAF file parsing and data extraction
* Temporal workflow for advisory processing
* Module NEVRA product version detection
* Multi-format timestamp handling

### Test Coverage
* Unit tests for RPM helpers
  - NEVRA parsing (modular/non-modular)
  - Distribution version extraction
  - Release string handling
* Tests for RHCSAF processing
  - Advisory scraping
  - Data extraction
  - Schema validation
* Tests for CSAF processing
  - Document parsing
  - Security/bugfix/enhancement advisories
  - Database operations validation

### CI Integration
* Added Bazel test targets
* Updated GitHub workflow

## Testing
Run the test suite:
```bash
$ bazel test --cache_test_results=no //apollo/tests:test_rpm_helpers --test_output=all
bazel test --cache_test_results=no //apollo/tests:test_rhcsaf --test_output=all
bazel test --cache_test_results=no //apollo/tests:test_csaf_processing --test_output=all
INFO: Analyzed target //apollo/tests:test_rpm_helpers (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
INFO: From Testing //apollo/tests:test_rpm_helpers:
==================== Test output for //apollo/tests:test_rpm_helpers:
...
----------------------------------------------------------------------
Ran 3 tests in 0.000s

OK
================================================================================
Target //apollo/tests:test_rpm_helpers up-to-date:
  bazel-bin/apollo/tests/test_rpm_helpers
INFO: Elapsed time: 0.367s, Critical Path: 0.29s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//apollo/tests:test_rpm_helpers                                          PASSED in 0.2s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed target //apollo/tests:test_rhcsaf (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
INFO: From Testing //apollo/tests:test_rhcsaf:
==================== Test output for //apollo/tests:test_rhcsaf:
================================================================================
Target //apollo/tests:test_rhcsaf up-to-date:
  bazel-bin/apollo/tests/test_rhcsaf
INFO: Elapsed time: 0.494s, Critical Path: 0.42s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//apollo/tests:test_rhcsaf                                               PASSED in 0.3s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 2 total actions
INFO: Analyzed target //apollo/tests:test_csaf_processing (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
INFO: From Testing //apollo/tests:test_csaf_processing:
==================== Test output for //apollo/tests:test_csaf_processing:
================================================================================
Target //apollo/tests:test_csaf_processing up-to-date:
  bazel-bin/apollo/tests/test_csaf_processing
INFO: Elapsed time: 0.871s, Critical Path: 0.80s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//apollo/tests:test_csaf_processing                                      PASSED in 0.6s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 2 total actions
```

## Notes
CSAF ingestion introduces some NEVRA handling changes:
* Epochs now present in Red Hat NEVRA entries
* No `.rpm` suffixes in NEVRA entries

These will be addressed in a follow-up PR.
