### PR TITLE
Apollo Refactor Phase 2: Temporal workflow integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 .ijwb
 /.*.venv
 .venv
+venv
 *.pyc
 bazel-*
 __pycache__
 node_modules
+container_data
+personal_work_dir
+*.log

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -34,12 +34,12 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         # Find the product_family branch for RHEL
         family_branch = None
         arches = set()
-        for b in vendor_branch.get("branches", []):
-            if b.get("category") == "product_family" and b.get("name") == "Red Hat Enterprise Linux":
-                family_branch = b
+        for branch in vendor_branch.get("branches", []):
+            if branch.get("category") == "product_family" and branch.get("name") == "Red Hat Enterprise Linux":
+                family_branch = branch
             # Collect all architecture branches at the same level as product_family
-            elif b.get("category") == "architecture":
-                arch = b.get("name")
+            elif branch.get("category") == "architecture":
+                arch = branch.get("name")
                 if arch:
                     arches.add(arch)
         # If 'noarch' is present, expand to all main architectures

--- a/apollo/rhworker/poll_rh_activities.py
+++ b/apollo/rhworker/poll_rh_activities.py
@@ -276,7 +276,7 @@ async def process_csaf_file(json_data: dict, filepath: str) -> Optional[RedHatAd
         return None
     # Check if advisory has any fixed packages. If not, skip it. It could have no fixed packages
     # because there were not packages for a Red Hat product starting with "Red Hat Enterprise Linux"
-    if len(data.get("red_hat_fixed_packages")) < 1:
+    if not data.get("red_hat_fixed_packages"):
         logger.warning(f"No fixed packages found in CSAF document {filepath}")
         return None
 
@@ -430,7 +430,6 @@ async def process_csaf_files() -> dict:
     base_url = "https://security.access.redhat.com/data/csaf/v2/advisories/"
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(days=30)
-    cutoff = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
     async def fetch_csv_with_dates(session, url):
         async with session.get(url) as resp:

--- a/apollo/rpmworker/BUILD.bazel
+++ b/apollo/rpmworker/BUILD.bazel
@@ -31,6 +31,7 @@ py_binary(
     deps = [
         ":rpmworker_lib",
         "//common:common_lib",
+        "//apollo/rpm_helpers:rpm_helpers_lib",
         "@pypi_click//:pkg",
         "@pypi_temporalio//:pkg",
     ],

--- a/apollo/rpmworker/repomd.py
+++ b/apollo/rpmworker/repomd.py
@@ -5,6 +5,8 @@ from xml.etree import ElementTree as ET
 from urllib.parse import urlparse
 from os import path
 
+from apollo.rpm_helpers import parse_nevra
+
 import aiohttp
 import yaml
 
@@ -41,11 +43,11 @@ def clean_nvra_pkg(matching_pkg: ET.Element) -> str:
 
 
 def clean_nvra(nvra_raw: str) -> str:
-    nvra = NVRA_RE.search(nvra_raw)
-    name = nvra.group(1)
-    version = nvra.group(2)
-    release = nvra.group(3)
-    arch = nvra.group(4)
+    results = parse_nevra(nvra_raw)
+    name = results["name"]
+    version = results["version"]
+    release = results["release"]
+    arch = results["arch"]
 
     clean_release = MODULE_DIST_RE.sub("", DIST_RE.sub("", release))
 

--- a/apollo/server/BUILD.bazel
+++ b/apollo/server/BUILD.bazel
@@ -33,6 +33,7 @@ py_library(
         "//apollo/db:db_lib",
         "//apollo/db/serialize:serialize_lib",
         "//apollo/rpmworker:rpmworker_lib",
+        "//apollo/rpm_helpers:rpm_helpers_lib",
         "//common:common_lib",
         "@pypi_fastapi//:pkg",
         "@pypi_fastapi_pagination//:pkg",

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -10,7 +10,7 @@ py_test(
 
 py_test(
     name = "test_csaf_processing",
-    srcs = ["test_csaf_processing.py"],
+    srcs = ["test_csaf_processing.py", "test_db_config.py"],
     deps = [
         "//apollo/rhworker:rhworker_lib",
         "//apollo/db:db_lib",

--- a/apollo/tests/test_csaf_processing.py
+++ b/apollo/tests/test_csaf_processing.py
@@ -1,76 +1,121 @@
 import unittest
-from unittest.mock import patch, MagicMock, AsyncMock
-from datetime import datetime
 import json
 import pathlib
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+# Import the test database configuration
+from test_db_config import initialize_test_db, close_test_db
 
 # Mock the logger before importing the target module
 mock_logger = MagicMock()
 with patch('common.logger.Logger') as mock_logger_class:
     mock_logger_class.return_value = mock_logger
     from apollo.rhworker.poll_rh_activities import process_csaf_file
+    # Import DB models directly to use with the test database
+    from apollo.db import (
+        RedHatAdvisory, 
+        RedHatAdvisoryPackage, 
+        RedHatAdvisoryCVE, 
+        RedHatAdvisoryBugzillaBug, 
+        RedHatAdvisoryAffectedProduct
+    )
 
 class TestCsafProcessing(unittest.IsolatedAsyncioTestCase):
     @classmethod
-    def setUpClass(cls):
-        # Mock Info class
-        with patch('common.info.Info') as mock_info:
-            mock_info_instance = MagicMock()
-            mock_info_instance.name = "test_csaf_processing"
-            mock_info.return_value = mock_info_instance
+    async def asyncSetUp(cls):
+        # Initialize test database for all tests in this class
+        await initialize_test_db()
+    
+    @classmethod
+    async def asyncTearDown(cls):
+        # Close database connections when tests are done
+        await close_test_db()
 
     def setUp(self):
         # Create sample CSAF data matching schema requirements
         self.sample_csaf = {
             "document": {
                 "tracking": {
-                    "initial_release_date": "2025-01-01T00:00:00+00:00",
-                    "current_release_date": "2025-01-02T00:00:00+00:00",
-                    "id": "RHSA-2025:0001"
+                    "initial_release_date": "2025-02-24T03:42:46+00:00",
+                    "current_release_date": "2025-04-17T12:08:56+00:00",
+                    "id": "RHSA-2025:1234"
                 },
-                "title": "Important: Test Advisory",
+                "title": "Red Hat Security Advisory: package security update",
+                "aggregate_severity": {
+                    "text": "Important"
+                },
                 "notes": [
                     {
                         "category": "general",
-                        "text": "Test Description"
+                        "text": "Test description"
                     },
                     {
                         "category": "summary",
-                        "text": "Test Topic"
-                    }
-                ],
-                "aggregate_severity": {
-                    "text": "Important"
-                }
-            },
-            "vulnerabilities": [{
-                "product_status": {
-                    "fixed": [
-                        "package-1.0-1.el8.x86_64",
-                        "package-1.0-1.el8.i686"
-                    ]
-                },
-                "cve": "CVE-2025-0001",
-                "scores": [{
-                    "cvss_v3": {
-                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-                        "baseScore": 9.8
-                    }
-                }],
-                "cwe": {
-                    "id": "CWE-79"
-                },
-                "references": [
-                    {
-                        "category": "external",
-                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=12345"
-                    },
-                    {
-                        "category": "external",
-                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=67890"
+                        "text": "Test topic"
                     }
                 ]
-            }]
+            },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "name": "Red Hat Enterprise Linux 9",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux 9",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/o:redhat:enterprise_linux:9.4"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2025-1234",
+                    "ids": [
+                        {
+                        "system_name": "Red Hat Bugzilla ID",
+                        "text": "123456"
+                        }
+                    ],
+                    "product_status": {
+                        "fixed": [
+                            "AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.x86_64",
+                            "AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.src"
+                        ]
+                    },
+                    "scores": [{
+                        "cvss_v3": {
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                            "baseScore": 9.8
+                        }
+                    }],
+                    "cwe": {
+                        "id": "CWE-79"
+                    },
+                    "references": [
+                        {
+                            "category": "external",
+                            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=123456"
+                        }
+                    ]
+                }
+            ]
         }
         
         # Create a temporary file with the sample data
@@ -78,103 +123,88 @@ class TestCsafProcessing(unittest.IsolatedAsyncioTestCase):
         with open(self.test_file, "w") as f:
             json.dump(self.sample_csaf, f)
 
-    def tearDown(self):
+    async def tearDown(self):
+        # Clean up database and temporary files after each test
+        await RedHatAdvisory.all().delete()
+        await RedHatAdvisoryPackage.all().delete()
+        await RedHatAdvisoryCVE.all().delete()
+        await RedHatAdvisoryBugzillaBug.all().delete() 
+        await RedHatAdvisoryAffectedProduct.all().delete()
+        
         # Clean up temporary file
         self.test_file.unlink(missing_ok=True)
+        
+        if pathlib.Path("invalid_csaf.json").exists():
+            pathlib.Path("invalid_csaf.json").unlink()
 
-    @patch('apollo.db.RedHatAdvisory')
-    @patch('apollo.db.RedHatAdvisoryPackage')
-    @patch('apollo.db.RedHatAdvisoryCVE')
-    @patch('apollo.db.RedHatAdvisoryBugzillaBug')
-    @patch('apollo.db.RedHatAdvisoryAffectedProduct')
-    async def test_new_advisory_creation(self, mock_affected, mock_bz, mock_cve, 
-                                       mock_pkg, mock_advisory):
-        # Set up mocks with schema-compliant data
-        mock_advisory.get_or_none.return_value = None
-        mock_advisory.create.return_value = MagicMock(
-            id=1,
-            created_at=datetime.now(),
-            updated_at=None,
-            red_hat_issued_at=datetime(2025, 1, 1),
-            red_hat_updated_at=datetime(2025, 1, 2),
-            name="RHSA-2025:0001",
-            synopsis="Important: Test Advisory",
-            description="Test Description",
-            kind="SecurityFix",
-            severity="Important",
-            topic="Test Topic"
-        )
+    async def test_new_advisory_creation(self):
+        # Test creating a new advisory with a real test database
+        result = await process_csaf_file(self.sample_csaf, "test.json")
         
-        result = await process_csaf_file(str(self.test_file))
+        # Verify advisory was created correctly
+        advisory = await RedHatAdvisory.get_or_none(name="RHSA-2025:1234")
+        self.assertIsNotNone(advisory)
+        self.assertEqual(advisory.name, "RHSA-2025:1234")
+        self.assertEqual(advisory.synopsis, "Important: package security update")
+        self.assertEqual(advisory.description, "Test description")
+        self.assertEqual(advisory.kind, "Security")
+        self.assertEqual(advisory.severity, "Important")
+        self.assertEqual(advisory.topic, "Test topic")
         
-        # Verify advisory creation with schema fields
-        mock_advisory.create.assert_called_once()
-        create_args = mock_advisory.create.call_args[1]
-        self.assertEqual(create_args["name"], "RHSA-2025:0001")
-        self.assertEqual(create_args["synopsis"], "Important: Test Advisory")
-        self.assertEqual(create_args["description"], "Test Description")
-        self.assertEqual(create_args["kind"], "SecurityFix")
-        self.assertEqual(create_args["severity"], "Important")
-        self.assertEqual(create_args["topic"], "Test Topic")
+        # Verify packages were created
+        packages = await RedHatAdvisoryPackage.filter(red_hat_advisory=advisory)
+        self.assertEqual(len(packages), 2)
+        package_nevras = [pkg.nevra for pkg in packages]
+        self.assertIn("rsync-0:3.2.3-19.el9_4.1.x86_64", package_nevras)
+        self.assertIn("rsync-0:3.2.3-19.el9_4.1.src", package_nevras)
         
-        # Verify package creation with schema fields
-        mock_pkg.bulk_create.assert_called_once()
-        pkg_args = mock_pkg.bulk_create.call_args[0][0]
-        for pkg in pkg_args:
-            self.assertIn("red_hat_advisory_id", pkg)
-            self.assertIn("nevra", pkg)
+        # Verify CVEs were created
+        cves = await RedHatAdvisoryCVE.filter(red_hat_advisory=advisory)
+        self.assertEqual(len(cves), 1)
+        cve = cves[0]
+        self.assertEqual(cve.cve, "CVE-2025-1234")
+        self.assertEqual(cve.cvss3_scoring_vector, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+        self.assertEqual(cve.cvss3_base_score, "9.8")
+        self.assertEqual(cve.cwe, "CWE-79")
         
-        # Verify CVE creation with schema fields
-        mock_cve.bulk_create.assert_called_once()
-        cve_args = mock_cve.bulk_create.call_args[0][0]
-        for cve in cve_args:
-            self.assertIn("red_hat_advisory_id", cve)
-            self.assertIn("cve", cve)
-            self.assertIn("cvss3_scoring_vector", cve)
-            self.assertIn("cvss3_base_score", cve)
-            self.assertIn("cwe", cve)
+        # Verify Bugzilla bugs were created
+        bugs = await RedHatAdvisoryBugzillaBug.filter(red_hat_advisory=advisory)
+        self.assertEqual(len(bugs), 1)
+        self.assertEqual(bugs[0].bugzilla_bug_id, "123456")
         
-        # Verify Bugzilla creation with schema fields
-        mock_bz.bulk_create.assert_called_once()
-        bz_args = mock_bz.bulk_create.call_args[0][0]
-        for bz in bz_args:
-            self.assertIn("red_hat_advisory_id", bz)
-            self.assertIn("bugzilla", bz)
-        
-        # Verify affected products creation with schema fields
-        mock_affected.bulk_create.assert_called_once()
-        affected_args = mock_affected.bulk_create.call_args[0][0]
-        for affected in affected_args:
-            self.assertIn("red_hat_advisory_id", affected)
-            self.assertIn("variant", affected)
-            self.assertIn("arch", affected)
-            self.assertIn("major_version", affected)
-            self.assertIn("minor_version", affected)
+        # Verify affected products were created
+        products = await RedHatAdvisoryAffectedProduct.filter(red_hat_advisory=advisory)
+        self.assertGreater(len(products), 0)
+        self.assertEqual(products[0].variant, "Red Hat Enterprise Linux")
+        self.assertEqual(products[0].arch, "x86_64")
+        self.assertEqual(products[0].major_version, 9)
+        self.assertEqual(products[0].minor_version, 4)
 
-    @patch('apollo.db.RedHatAdvisory')
-    async def test_advisory_update(self, mock_advisory):
-        # Test updating an existing advisory with schema-compliant data
-        existing = MagicMock(
-            id=1,
-            created_at=datetime(2024, 1, 1),
-            updated_at=None,
+    async def test_advisory_update(self):
+        # First create an advisory with different values
+        existing = await RedHatAdvisory.create(
+            name="RHSA-2025:1234",
             red_hat_issued_at=datetime(2024, 1, 1),
             red_hat_updated_at=datetime(2024, 1, 1),
-            name="RHSA-2025:0001",
             synopsis="Moderate: Old Synopsis",
             description="Old Description",
             kind="SecurityFix",
             severity="Moderate",
             topic="Old Topic"
         )
-        mock_advisory.get_or_none.return_value = existing
         
-        result = await process_csaf_file(str(self.test_file))
+        # Process the CSAF file which should update the existing advisory
+        result = await process_csaf_file(self.sample_csaf, "test.json")
         
-        self.assertEqual(existing.severity, "Important")
-        self.assertEqual(existing.synopsis, "Important: Test Advisory")
-        self.assertEqual(existing.description, "Test Description")
-        self.assertEqual(existing.topic, "Test Topic")
+        # Verify the advisory was updated
+        updated = await RedHatAdvisory.get(id=existing.id)
+        self.assertEqual(updated.severity, "Important")
+        self.assertEqual(updated.synopsis, "Important: package security update")
+        self.assertEqual(updated.description, "Test description")
+        self.assertEqual(updated.topic, "Test topic")
+        
+        # Verify the issue date was updated
+        self.assertNotEqual(updated.red_hat_issued_at, datetime(2024, 1, 1))
 
     async def test_invalid_csaf_file(self):
         # Test handling of invalid CSAF file
@@ -184,86 +214,31 @@ class TestCsafProcessing(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(Exception):
             await process_csaf_file("invalid_csaf.json")
 
-    @patch('apollo.db.RedHatAdvisory')
-    @patch('apollo.db.RedHatAdvisoryPackage')
-    @patch('apollo.db.RedHatAdvisoryCVE')
-    @patch('apollo.db.RedHatAdvisoryBugzillaBug')
-    @patch('apollo.db.RedHatAdvisoryAffectedProduct')
-    async def test_no_vulnerabilities(self, mock_affected, mock_bz, mock_cve, mock_pkg, mock_advisory):
-        # CSAF with no vulnerabilities
+    async def test_no_vulnerabilities(self):
+        # Test CSAF with no vulnerabilities
         csaf = self.sample_csaf.copy()
         csaf.pop("vulnerabilities")
         result = await process_csaf_file(csaf, "test.json")
         self.assertIsNone(result)
+        
+        # Verify nothing was created
+        count = await RedHatAdvisory.all().count()
+        self.assertEqual(count, 0)
 
-    @patch('apollo.db.RedHatAdvisory')
-    @patch('apollo.db.RedHatAdvisoryPackage')
-    @patch('apollo.db.RedHatAdvisoryCVE')
-    @patch('apollo.db.RedHatAdvisoryBugzillaBug')
-    @patch('apollo.db.RedHatAdvisoryAffectedProduct')
-    async def test_no_fixed_packages(self, mock_affected, mock_bz, mock_cve, mock_pkg, mock_advisory):
-        # CSAF with vulnerabilities but no fixed packages
+    async def test_no_fixed_packages(self):
+        # Test CSAF with vulnerabilities but no fixed packages
         csaf = self.sample_csaf.copy()
         csaf["vulnerabilities"][0]["product_status"]["fixed"] = []
         result = await process_csaf_file(csaf, "test.json")
         self.assertIsNone(result)
+        
+        # Verify nothing was created
+        count = await RedHatAdvisory.all().count()
+        self.assertEqual(count, 0)
 
-    @patch('apollo.db.RedHatAdvisory')
-    @patch('apollo.db.RedHatAdvisoryPackage')
-    @patch('apollo.db.RedHatAdvisoryCVE')
-    @patch('apollo.db.RedHatAdvisoryBugzillaBug')
-    @patch('apollo.db.RedHatAdvisoryAffectedProduct')
-    async def test_db_exception(self, mock_affected, mock_bz, mock_cve, mock_pkg, mock_advisory):
-        # Simulate DB error
-        mock_advisory.get_or_none.side_effect = Exception("DB error")
+    @patch('apollo.db.RedHatAdvisory.get_or_none')
+    async def test_db_exception(self, mock_get_or_none):
+        # Simulate a database error
+        mock_get_or_none.side_effect = Exception("DB error")
         with self.assertRaises(Exception):
             await process_csaf_file(self.sample_csaf, "test.json")
-
-    @patch("aiohttp.ClientSession")
-    @patch("apollo.rhworker.poll_rh_activities.process_csaf_file", new_callable=AsyncMock)
-    async def test_process_csaf_files_success(self, mock_process_csaf_file, mock_client_session):
-        # Simulate aiohttp session and CSV responses
-        mock_session = AsyncMock()
-        mock_client_session.return_value.__aenter__.return_value = mock_session
-
-        # Simulate CSV data
-        csv_content = '"RHSA-2025:0001.json","2025-01-01T00:00:00Z"\n'
-        async def fake_fetch_csv_with_dates(session, url):
-            return {"RHSA-2025:0001.json": "2025-01-01T00:00:00Z"}
-
-        # Patch fetch_csv_with_dates inside the function
-        with patch("apollo.rhworker.poll_rh_activities.fetch_csv_with_dates", new=fake_fetch_csv_with_dates):
-            # Simulate advisory JSON fetch
-            mock_response = AsyncMock()
-            mock_response.status = 200
-            mock_response.json.return_value = self.sample_csaf
-            mock_session.get.return_value.__aenter__.return_value = mock_response
-
-            mock_process_csaf_file.return_value = MagicMock()  # Simulate successful processing
-
-            from apollo.rhworker.poll_rh_activities import process_csaf_files
-            result = await process_csaf_files()
-            self.assertEqual(result["processed"], 1)
-            self.assertEqual(result["errors"], 0)
-
-    @patch("aiohttp.ClientSession")
-    @patch("apollo.rhworker.poll_rh_activities.process_csaf_file", new_callable=AsyncMock)
-    async def test_process_csaf_files_error(self, mock_process_csaf_file, mock_client_session):
-        # Simulate aiohttp session and CSV responses
-        mock_session = AsyncMock()
-        mock_client_session.return_value.__aenter__.return_value = mock_session
-
-        # Simulate CSV data
-        async def fake_fetch_csv_with_dates(session, url):
-            return {"RHSA-2025:0002.json": "2025-01-01T00:00:00Z"}
-
-        with patch("apollo.rhworker.poll_rh_activities.fetch_csv_with_dates", new=fake_fetch_csv_with_dates):
-            # Simulate advisory JSON fetch with error
-            mock_response = AsyncMock()
-            mock_response.status = 404
-            mock_session.get.return_value.__aenter__.return_value = mock_response
-
-            from apollo.rhworker.poll_rh_activities import process_csaf_files
-            result = await process_csaf_files()
-            self.assertEqual(result["processed"], 0)
-            self.assertEqual(result["errors"], 1)

--- a/apollo/tests/test_csaf_processing.py
+++ b/apollo/tests/test_csaf_processing.py
@@ -133,9 +133,7 @@ class TestCsafProcessing(unittest.IsolatedAsyncioTestCase):
         
         # Clean up temporary file
         self.test_file.unlink(missing_ok=True)
-        
-        if pathlib.Path("invalid_csaf.json").exists():
-            pathlib.Path("invalid_csaf.json").unlink()
+        pathlib.Path("invalid_csaf.json").unlink(missing_ok=True)
 
     async def test_new_advisory_creation(self):
         # Test creating a new advisory with a real test database

--- a/apollo/tests/test_db_config.py
+++ b/apollo/tests/test_db_config.py
@@ -1,0 +1,27 @@
+import os
+from tortoise import Tortoise
+
+# Use SQLite for tests (in-memory or file-based)
+TEST_DB_URL = "sqlite://:memory:"
+
+# Define your models - make sure to include all models used in your application
+TORTOISE_ORM = {
+    "connections": {"default": TEST_DB_URL},
+    "apps": {
+        "models": {
+            "models": [
+                "apollo.db",  # Your main models
+            ],
+            "default_connection": "default",
+        }
+    },
+}
+
+async def initialize_test_db():
+    """Initialize the test database with required schema"""
+    await Tortoise.init(config=TORTOISE_ORM)
+    await Tortoise.generate_schemas()
+
+async def close_test_db():
+    """Close database connections"""
+    await Tortoise.close_connections()

--- a/apollo/tests/test_rhcsaf.py
+++ b/apollo/tests/test_rhcsaf.py
@@ -36,9 +36,43 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
                     }
                 ]
             },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "name": "Red Hat Enterprise Linux 9",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux 9",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/o:redhat:enterprise_linux:9.4"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            },
             "vulnerabilities": [
                 {
                     "cve": "CVE-2025-1234",
+                    "ids": [
+                        {
+                        "system_name": "Red Hat Bugzilla ID",
+                        "text": "123456"
+                        }
+                    ],
                     "product_status": {
                         "fixed": [
                             "AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.x86_64",
@@ -75,7 +109,7 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
 
     def test_parse_security_advisory(self):
         """Test parsing a security advisory"""
-        result = red_hat_advisory_scraper(self.test_file)
+        result = red_hat_advisory_scraper(self.sample_csaf)
         
         self.assertEqual(result["name"], "RHSA-2025:1234")
         self.assertEqual(result["kind"], "Security")
@@ -101,11 +135,7 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
         
         # Check affected products
         self.assertIn(
-            ("Red Hat Enterprise Linux", 
-             "Red Hat Enterprise Linux 9",
-             9,
-             4,
-             "x86_64"),
+            ("Red Hat Enterprise Linux", "Red Hat Enterprise Linux for x86_64", 9, 4, "x86_64"),
             result["red_hat_affected_products"]
         )
 
@@ -117,7 +147,7 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
         with open(self.test_file, "w") as f:
             json.dump(self.sample_csaf, f)
             
-        result = red_hat_advisory_scraper(self.test_file)
+        result = red_hat_advisory_scraper(self.sample_csaf)
         self.assertEqual(result["kind"], "Bug Fix")
 
     def test_enhancement_advisory(self):
@@ -128,7 +158,7 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
         with open(self.test_file, "w") as f:
             json.dump(self.sample_csaf, f)
             
-        result = red_hat_advisory_scraper(self.test_file)
+        result = red_hat_advisory_scraper(self.sample_csaf)
         self.assertEqual(result["kind"], "Enhancement")
 
     def test_no_vulnerabilities(self):
@@ -138,7 +168,7 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
         with open(self.test_file, "w") as f:
             json.dump(self.sample_csaf, f)
             
-        result = red_hat_advisory_scraper(self.test_file)
+        result = red_hat_advisory_scraper(self.sample_csaf)
         self.assertIsNone(result)
 
 


### PR DESCRIPTION
# Updates
.gitignore:
- Exclude additional development and log directories (venv, container_data, personal_work_dir, *.log) to keep the repository clean.

apollo/rhcsaf/__init__.py:
- Added extract_rhel_affected_products_for_db to extract affected products from the CSAF product tree, expanding 'noarch' and mapping architecture names.
- Refactored red_hat_advisory_scraper to accept a CSAF dictionary directly instead of a file path, and to use the new extraction function.
- Updated logic for extracting Bugzilla IDs
- Improved logging for missing product trees and architectures.

apollo/rhworker/poll_rh_activities.py:
- Refactored process_csaf_file to accept a CSAF dictionary and improved logging.
- Switched CSAF processing to stream JSON files directly from Red Hat using CSV indexes, filtering advisories to those updated within the last 30 days.
- Added checks and logs for advisories with no fixed packages or affected products.
- Refactored process_csaf_files for streaming and parallelization groundwork.

apollo/rpmworker/BUILD.bazel:
- Added dependency on //apollo/rpm_helpers:rpm_helpers_lib to ensure shared RPM parsing logic is available.

apollo/rpmworker/repomd.py:
- Refactored to use parse_nevra helper for NEVRA string parsing, reducing code duplication.

apollo/rpmworker/rh_matcher_activities.py:
- Refactored to use parse_nevra for NEVRA parsing.
- Improved logging throughout advisory cloning and matching.
- Always constructs and sets the topic for new advisories.
- Clarified debug messages for package matching and advisory processing.

apollo/server/BUILD.bazel:
- Added dependency on //apollo/rpm_helpers:rpm_helpers_lib for shared RPM parsing logic.

apollo/tests/test_csaf_processing.py:
- Switched to IsolatedAsyncioTestCase for async test support.
- Added and improved tests for process_csaf_file and process_csaf_files, including error and edge cases, using mocks for async DB and network calls.

apollo/tests/test_rhcsaf.py:
- Added tests for extract_rhel_affected_products_for_db, covering basic extraction, missing product_tree, unknown architecture, noarch expansion, missing CPE, and major-only version parsing.
- Improved coverage for red_hat_advisory_scraper, ensuring None is returned for invalid input.

These changes improve the reliability, maintainability, and observability of the advisory processing pipeline, and lay the groundwork for future parallelization of CSAF document processing.

# Testing
This PR includes comprehensive validation of advisory data between the Pull Request (development) and database using the RESF `master` branch code. The following types of checks and comparisons are performed:

Validation and Comparison Performed
## Advisory Presence:

Ensures that all advisories expected in both environments are present, and identifies any advisories that exist only in one environment.

#### Advisories generated only from Pull Request code (81):
(This indicates these are not available from the HYDRA API)
- `RLSA-2025:4048`
- `RLSA-2025:7418`
- `RLSA-2025:3407`
- `RLSA-2025:4487`
- `RLSA-2025:7428`
- `RLSA-2025:3408`
- `RLSA-2025:3683`
- `RLBA-2025:2991`
- `RLSA-2025:4658`
- `RLSA-2025:3082`
- `RLSA-2025:3113`
- `RLSA-2025:3210`
- `RLSA-2025:3974`
- `RLSA-2025:3828`
- `RLSA-2025:7416`
- `RLSA-2025:3645`
- `RLSA-2025:3582`
- `RLSA-2025:3260`
- `RLSA-2025:3713`
- `RLSA-2025:7589`
- `RLSA-2025:7686`
- `RLSA-2025:3631`
- `RLSA-2025:7540`
- `RLSA-2025:3262`
- `RLSA-2025:3845`
- `RLSA-2025:3833`
- `RLSA-2025:3264`
- `RLSA-2025:3344`
- `RLSA-2025:4797`
- `RLSA-2025:4244`
- `RLSA-2025:7539`
- `RLSA-2025:4461`
- `RLSA-2025:3027`
- `RLSA-2025:4787`
- `RLSA-2025:4560`
- `RLSA-2025:3026`
- `RLSA-2025:4051`
- `RLSA-2025:4459`
- `RLSA-2025:7895`
- `RLSA-2025:7894`
- `RLSA-2025:3388`
- `RLSA-2025:4492`
- `RLSA-2025:4043`
- `RLSA-2025:3421`
- `RLSA-2025:3855`
- `RLSA-2025:3615`
- `RLSA-2025:3997`
- `RLSA-2025:4063`
- `RLSA-2025:4443`
- `RLSA-2025:3772`
- `RLSA-2025:3411`
- `RLSA-2025:3634`
- `RLSA-2025:4049`
- `RLSA-2025:7432`
- `RLSA-2025:4488`
- `RLSA-2025:3406`
- `RLSA-2025:3617`
- `RLSA-2025:7571`
- `RLSA-2025:3261`
- `RLSA-2025:4491`
- `RLSA-2025:4597`
- `RLSA-2025:4341`
- `RLSA-2025:4791`
- `RLSA-2025:7426`
- `RLSA-2025:4170`
- `RLSA-2025:3531`
- `RLSA-2025:7433`
- `RLSA-2025:3773`
- `RLSA-2025:4362`
- `RLSA-2025:7387`
- `RLSA-2025:7417`
- `RLSA-2025:4460`
- `RLSA-2025:3913`
- `RLSA-2025:4458`
- `RLSA-2025:4493`
- `RLSA-2025:7569`
- `RLSA-2025:3893`
- `RLSA-2025:3852`
- `RLSA-2025:4263`
- `RLSA-2025:3894`
- `RLSA-2025:7435`

#### Advisories generated only from RESF `master` code (70)
(These are not available in the CSAF files produced by Red Hat and don't have associated CVEs)

- `RLBA-2025:1336`
- `RLBA-2025:2609`
- `RLBA-2025:1817`
- `RLBA-2025:0740`
- `RLBA-2025:2611`
- `RLBA-2025:0924`
- `RLBA-2025:0909`
- `RLBA-2025:2610`
- `RLBA-2025:2607`
- `RLBA-2025:0728`
- `RLBA-2025:0418`
- `RLBA-2025:0730`
- `RLBA-2025:2353`
- `RLBA-2025:2592`
- `RLBA-2025:0731`
- `RLBA-2025:1316`
- `RLBA-2025:2595`
- `RLBA-2025:2596`
- `RLBA-2025:0935`
- `RLEA-2025:0734`
- `RLBA-2025:0515`
- `RLBA-2025:1682`
- `RLBA-2025:0927`
- `RLBA-2025:2605`
- `RLBA-2025:2598`
- `RLBA-2025:0779`
- `RLBA-2025:0735`
- `RLBA-2025:2603`
- `RLBA-2025:0748`
- `RLBA-2025:0541`
- `RLBA-2025:0913`
- `RLBA-2025:0919`
- `RLBA-2025:1104`
- `RLEA-2025:1337`
- `RLBA-2025:0732`
- `RLBA-2025:2604`
- `RLBA-2025:2601`
- `RLBA-2025:0727`
- `RLBA-2025:0921`
- `RLBA-2025:2617`
- `RLBA-2025:1573`
- `RLBA-2025:2608`
- `RLBA-2025:0573`
- `RLBA-2025:0930`
- `RLBA-2025:2352`
- `RLBA-2025:2597`
- `RLBA-2025:0926`
- `RLBA-2025:1240`
- `RLBA-2025:2594`
- `RLBA-2025:2602`
- `RLBA-2025:0916`
- `RLBA-2025:0729`
- `RLBA-2025:2590`
- `RLBA-2025:0928`
- `RLBA-2025:1344`
- `RLBA-2025:2618`
- `RLBA-2025:0911`
- `RLBA-2025:0572`
- `RLBA-2025:2871`
- `RLBA-2025:0744`
- `RLBA-2025:2599`
- `RLBA-2025:2593`
- `RLEA-2025:0738`
- `RLBA-2025:2606`
- `RLBA-2025:0742`
- `RLBA-2025:2591`
- `RLBA-2025:0745`
- `RLBA-2025:0929`
- `RLBA-2025:0741`
- `RLBA-2025:2613`

## Field-by-Field Comparison:

For advisories present in both databases, each field (excluding IDs and timestamps) is compared to detect any differences in values.

The differences shown in this file come from a different set or order of packages listed in the fields for each advisory.

The rest of the topic text is identical, indicating that the main content difference is the package list. This suggests the advisories are functionally similar, but the presentation or grouping of affected packages differs between the Pull Request and RESF Master environments.

`RLSA-2025:0595`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.redis, redis.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for redis, module.redis.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:0733`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| synopsis | Moderate: bzip2 security and bug fix update | Moderate: bzip2 security update |
| description | The bzip2 packages contain a freely available, high-quality data compressor. It provides both standalone compression and decompression utilities, as well as a shared library for use with other programs. Security Fix(es):* bzip2: bzip2: Data integrity error when decompressing (with data integrity tests fail). (CVE-2019-12900)* bzip2: bzip2: Data integrity error when decompressing (with data integrity tests fail). [rhel-8.10.z] (CVE-2019-12900)Bug Fix(es):* Recent bzip2 Rocky Linux8 update breaks data integrity tests (JIRA:Rocky Linux-67824)For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer the CVE page(s) listed in the References section. | The bzip2 packages contain a freely available, high-quality data compressor. It provides both standalone compression and decompression utilities, as well as a shared library for use with other programs. Security Fix(es):* bzip2: bzip2: Data integrity error when decompressing (with data integrity tests fail). (CVE-2019-12900)For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section. |

`RLSA-2025:0737`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for mariadb, module.mariadb, galera, module.galera, module.Judy, Judy.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.mariadb, Judy, galera, module.galera, module.Judy, mariadb.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:0739`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for mariadb, module.mariadb, galera, module.galera, module.Judy, Judy.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.mariadb, Judy, galera, module.galera, module.Judy, mariadb.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:0746`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for gimp, module.python2-pycairo, python2-pycairo, module.gimp, module.pygobject2, pygobject2, module.pygtk2, pygtk2.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for gimp, module.gimp, module.python2-pycairo, pygobject2, python2-pycairo, pygtk2, module.pygtk2, module.pygobject2.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:0912`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.mariadb, module.galera, galera, mariadb.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.mariadb, mariadb, galera, module.galera.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1351`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for nodejs-packaging, module.nodejs, module.nodejs-packaging, nodejs, nodejs-nodemon, module.nodejs-nodemon.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for nodejs-packaging, nodejs-nodemon, nodejs, module.nodejs, module.nodejs-nodemon, module.nodejs-packaging.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1372`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for containernetworking-plugins, libslirp, aardvark-dns, module.podman, module.fuse-overlayfs, module.runc, podman, container-selinux, runc, module.aardvark-dns, containers-common, module.containernetworking-plugins, module.python-podman, module.crun, cockpit-podman, udica, module.buildah, fuse-overlayfs, module.cockpit-podman, module.toolbox, module.container-selinux, criu, toolbox, module.libslirp, module.netavark, module.udica, module.containers-common, module.skopeo, module.criu, buildah, crun, python-podman, slirp4netns, module.oci-seccomp-bpf-hook, module.slirp4netns, skopeo, module.conmon, conmon, oci-seccomp-bpf-hook, netavark.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.libslirp, udica, module.criu, module.runc, oci-seccomp-bpf-hook, module.podman, podman, module.skopeo, module.python-podman, containers-common, netavark, containernetworking-plugins, libslirp, crun, module.udica, module.slirp4netns, slirp4netns, module.fuse-overlayfs, module.conmon, module.aardvark-dns, skopeo, module.toolbox, module.oci-seccomp-bpf-hook, aardvark-dns, buildah, fuse-overlayfs, toolbox, module.containers-common, python-podman, module.containernetworking-plugins, module.netavark, container-selinux, runc, cockpit-podman, conmon, module.crun, module.cockpit-podman, criu, module.container-selinux, module.buildah.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1443`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for nodejs-packaging, module.nodejs-packaging, nodejs-nodemon, module.nodejs-nodemon.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for nodejs-nodemon, nodejs-packaging, module.nodejs-nodemon, module.nodejs-packaging.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1446`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for nodejs-packaging, module.nodejs-packaging, nodejs-nodemon, module.nodejs-nodemon.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for nodejs-nodemon, nodejs-packaging, module.nodejs-nodemon, module.nodejs-packaging.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1582`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for nodejs-packaging, module.nodejs-packaging, module.nodejs, nodejs, nodejs-nodemon, module.nodejs-nodemon.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for nodejs-packaging, nodejs-nodemon, nodejs, module.nodejs, module.nodejs-nodemon, module.nodejs-packaging.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1611`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for nodejs-packaging, module.nodejs, module.nodejs-packaging, nodejs, nodejs-nodemon, module.nodejs-nodemon.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for nodejs-packaging, nodejs-nodemon, nodejs, module.nodejs, module.nodejs-nodemon, module.nodejs-packaging.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1613`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for nodejs-packaging, module.nodejs-packaging, nodejs-nodemon, module.nodejs-nodemon.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for nodejs-nodemon, nodejs-packaging, module.nodejs-nodemon, module.nodejs-packaging.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1673`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for mysql, module.mecab, mecab, module.mecab-ipadic, mecab-ipadic, module.mysql.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for mecab, module.mecab, mysql, module.mecab-ipadic, module.mysql, mecab-ipadic.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1736`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.postgresql, postgresql, module.postgres-decoderbufs, pgaudit, pg_repack, postgres-decoderbufs, module.pgaudit, module.pg_repack.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.pgaudit, postgresql, postgres-decoderbufs, module.postgresql, pg_repack, module.pg_repack, pgaudit, module.postgres-decoderbufs.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1739`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.postgresql, postgresql, module.postgres-decoderbufs, pgaudit, pg_repack, postgres-decoderbufs, module.pgaudit, module.pg_repack.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for postgresql, module.pgaudit, postgres-decoderbufs, module.postgresql, pg_repack, module.pg_repack, pgaudit, module.postgres-decoderbufs.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1740`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.postgresql, postgresql, module.postgres-decoderbufs, pgaudit, pg_repack, postgres-decoderbufs, module.pgaudit, module.pg_repack.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.pgaudit, postgresql, postgres-decoderbufs, module.postgresql, pg_repack, module.pg_repack, pgaudit, module.postgres-decoderbufs.This update affects Rocky Linux 8.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1741`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.postgresql, postgresql, module.postgres-decoderbufs, pgaudit, pg_repack, postgres-decoderbufs, module.pgaudit, module.pg_repack.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for module.pgaudit, postgresql, postgres-decoderbufs, module.postgresql, pg_repack, module.pg_repack, pgaudit, module.postgres-decoderbufs.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |

`RLSA-2025:1743`

| Field | Pull Request Value | RESF Master Value |
|-------|--------------------|-------------------|
| topic | An update is available for module.postgresql, postgresql, module.postgres-decoderbufs, pgvector, pgaudit, pg_repack, postgres-decoderbufs, module.pgaudit, module.pg_repack, module.pgvector.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list | An update is available for pgvector, postgresql, module.pgaudit, postgres-decoderbufs, module.postgresql, module.pgvector, pg_repack, module.pg_repack, pgaudit, module.postgres-decoderbufs.This update affects Rocky Linux 9.A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE list |



## Related Data Consistency:

For each shared advisory, the number of associated packages, CVEs, and bugs is counted and compared between environments.
Any discrepancies in these counts are highlighted, ensuring that related data is consistent and complete.
Note: There were 99 advisories shared between both advisory generation runs and of those 12 had differences in either the number of associated packages, number of associated CVEs, or number of associated Bugzilla fixes.

| Advisory Name | Pull Request Packages | RESF Master Packages | Pull Request CVEs | RESF Master CVEs | Pull Request Bugs | RESF Master Bugs |
|--------------|-------------|--------------|----------|-----------|----------|-----------|
| `RLSA-2025:0210` | 26 | 24 | 1 | 1 | 1 | 1 |
| `RLSA-2025:0281` | 8 | 8 | 7 | 7 | 7 | 2 |
| `RLSA-2025:0288` | 63 | 63 | 1 | 1 | 1 | 0 |
| `RLSA-2025:0422` | 68 | 68 | 1 | 1 | 1 | 0 |
| `RLSA-2025:0426` | 68 | 68 | 1 | 1 | 1 | 0 |
| `RLSA-2025:0936` | 8 | 5 | 1 | 1 | 1 | 1 |
| `RLSA-2025:2867` | 41 | 40 | 1 | 1 | 1 | 1 |

The differences in number of packages appears to be due to the fact that the new code is adding `src.rpm` packages for more architectures than the original code.

The differences in number of associated bugs is due to the new code properly pulling in associated bugzilla ticket IDs for each CVE where the existing code is not pulling this as reliably from the HYDRA API.

