### PR TITLE
add upsert_last_indexed_at function

### DIFF
--- a/apollo/rhworker/poll_rh_workflow.py
+++ b/apollo/rhworker/poll_rh_workflow.py
@@ -31,8 +31,13 @@ class PollRHCSAFAdvisoriesWorkflow:
     """
     @workflow.run
     async def run(self) -> None:
+        from_timestamp = await workflow.execute_activity(
+            "get_last_indexed_date",
+            start_to_close_timeout=datetime.timedelta(seconds=20),
+        )
         await workflow.execute_activity(
             "process_csaf_files",
+            from_timestamp,
             start_to_close_timeout=datetime.timedelta(hours=2),
         )
 


### PR DESCRIPTION
### poll_rh_activities.py
- **Added `upsert_last_indexed_at` function:**  
  This async function creates or updates the `last_indexed_at` field in the `RedHatIndexState` table, only updating if the new date is after the current value. It also converts string dates to `datetime` as needed.
- **Refactored `get_rh_advisories`:**  
  Now uses `await upsert_last_indexed_at(advisory_last_indexed_at)` instead of duplicating the logic for updating/creating the index state.
- **Refactored `process_csaf_file`:**  
  After processing, it now updates the index state using `upsert_last_indexed_at` with the latest date from the CSAF data.
- **Changed `process_csaf_files` signature:**  
  Now accepts an optional `from_timestamp` argument.
- **Filtering advisories:**  
  Instead of filtering by the last 30 days, advisories are now filtered based on the provided `from_timestamp`. If `from_timestamp` is not set, all advisories are included.

### poll_rh_workflow.py
- **`PollRHCSAFAdvisoriesWorkflow` updated:**  
  Now fetches `from_timestamp` using the `get_last_indexed_date` activity and passes it to the `process_csaf_files` activity.