### PR TITLE
Rockythorn apollo csaf phase3

### DIFF
--- a/apollo/rhworker/poll_rh_activities.py
+++ b/apollo/rhworker/poll_rh_activities.py
@@ -27,6 +27,193 @@ OVAL_NS = {"": "http://oval.mitre.org/XMLSchema/oval-definitions-5"}
 bz_re = re.compile(r"BZ#([0-9]+)")
 
 
+async def create_or_update_advisory_packages(
+    advisory: RedHatAdvisory,
+    new_nevras: set,
+    update_advisory: bool = False,
+) -> None:
+    """
+    Add new RedHatAdvisoryPackage entries for the given advisory.
+    If update_advisory is True, remove packages not in the new set.
+    """
+    logger = Logger()
+    logger.info(f"Creating or updating packages for advisory {advisory.name}")
+
+    existing_packages = set(
+        p.nevra for p in await RedHatAdvisoryPackage.filter(red_hat_advisory_id=advisory.id).all()
+    )
+
+    # Add new packages
+    to_add = new_nevras - existing_packages
+    if to_add:
+        logger.info(f"Adding new packages for advisory {advisory.name}: {to_add}")
+        await RedHatAdvisoryPackage.bulk_create([
+            RedHatAdvisoryPackage(
+                red_hat_advisory_id=advisory.id,
+                nevra=nevra
+            ) for nevra in to_add
+        ], ignore_conflicts=True)
+    else:
+        logger.info(f"No new packages to add for advisory {advisory.name}")
+
+    # Remove packages not in the new set if updating
+    if update_advisory:
+        to_remove = existing_packages - new_nevras
+        if to_remove:
+            logger.info(f"Removing packages for advisory {advisory.name}: {to_remove}")
+            await RedHatAdvisoryPackage.filter(
+                red_hat_advisory_id=advisory.id, nevra__in=list(to_remove)
+            ).delete()
+        else:
+            logger.info(f"No packages to remove for advisory {advisory.name}")
+
+
+async def create_or_update_advisory_cves(
+    advisory: RedHatAdvisory,
+    new_cve_tuples: set,
+    update_advisory: bool = False,
+) -> None:
+    """
+    Add new RedHatAdvisoryCVE entries for the given advisory.
+    If update_advisory is True, remove CVEs not in the new set.
+    new_cve_tuples: set of (cve_id, vector, score, cwe)
+    """
+    logger = Logger()
+    logger.info(f"Creating or updating CVEs for advisory {advisory.name}")
+
+    # Get existing CVEs for this advisory
+    existing_cves = {
+        (c.cve, c.cvss3_scoring_vector, c.cvss3_base_score, c.cwe)
+        for c in await RedHatAdvisoryCVE.filter(red_hat_advisory_id=advisory.id).all()
+    }
+    existing_cve_ids = {c[0] for c in existing_cves}
+    new_cve_ids = {c[0] for c in new_cve_tuples}
+
+    # Add new CVEs
+    to_add = new_cve_tuples - existing_cves
+    if to_add:
+        logger.info(f"Adding new CVEs for advisory {advisory.name}: {to_add}")
+        await RedHatAdvisoryCVE.bulk_create([
+            RedHatAdvisoryCVE(
+                red_hat_advisory_id=advisory.id,
+                cve=cve_id,
+                cvss3_scoring_vector=vector,
+                cvss3_base_score=str(score) if score else None,
+                cwe=cwe if cwe else None,
+            ) for (cve_id, vector, score, cwe) in to_add
+        ], ignore_conflicts=True)
+    else:
+        logger.info(f"No new CVEs to add for advisory {advisory.name}")
+
+    # Remove CVEs not in the new set if updating
+    if update_advisory:
+        to_remove_ids = existing_cve_ids - new_cve_ids
+        if to_remove_ids:
+            logger.info(f"Removing CVEs for advisory {advisory.name}: {to_remove_ids}")
+            await RedHatAdvisoryCVE.filter(
+                red_hat_advisory_id=advisory.id, cve__in=list(to_remove_ids)
+            ).delete()
+        else:
+            logger.info(f"No CVEs to remove for advisory {advisory.name}")
+
+
+async def create_or_update_advisory_bugzilla_bugs(
+    advisory,
+    new_bug_ids: set,
+    update_advisory: bool = False,
+) -> None:
+    """
+    Add new RedHatAdvisoryBugzillaBug entries for the given advisory.
+    If update_advisory is True, remove bugs not in the new set.
+    """
+    logger = Logger()
+    logger.info(f"Creating or updating Bugzilla bugs for advisory {advisory.name}")
+
+    # Get existing Bugzilla bug IDs for this advisory
+    existing_bugs = set(
+        b.bugzilla_bug_id for b in await RedHatAdvisoryBugzillaBug.filter(red_hat_advisory_id=advisory.id).all()
+    )
+
+    # Add new bugs
+    to_add = new_bug_ids - existing_bugs
+    if to_add:
+        logger.info(f"Adding new Bugzilla bugs for advisory {advisory.name}: {to_add}")
+        await RedHatAdvisoryBugzillaBug.bulk_create([
+            RedHatAdvisoryBugzillaBug(
+                red_hat_advisory_id=advisory.id,
+                bugzilla_bug_id=bug_id,
+                description=""  # No description available in CSAF data
+            ) for bug_id in to_add
+        ], ignore_conflicts=True)
+    else:
+        logger.info(f"No new Bugzilla bugs to add for advisory {advisory.name}")
+
+    # Remove bugs not in the new set if updating
+    if update_advisory:
+        to_remove = existing_bugs - new_bug_ids
+        if to_remove:
+            logger.info(f"Removing Bugzilla bugs for advisory {advisory.name}: {to_remove}")
+            await RedHatAdvisoryBugzillaBug.filter(
+                red_hat_advisory_id=advisory.id, bugzilla_bug_id__in=list(to_remove)
+            ).delete()
+        else:
+            logger.info(f"No Bugzilla bugs to remove for advisory {advisory.name}")
+
+
+async def create_or_update_advisory_affected_products(
+    advisory,
+    new_products: set,
+    update_advisory: bool = False,
+) -> None:
+    """
+    Add new RedHatAdvisoryAffectedProduct entries for the given advisory.
+    If update_advisory is True, remove affected products not in the new set.
+    new_products: set of (variant, name, major_version, minor_version, arch)
+    """
+    logger = Logger()
+    logger.info(f"Creating or updating affected products for advisory {advisory.name}")
+
+    # Get existing affected products for this advisory
+    existing_products = {
+        (p.variant, p.name, p.major_version, p.minor_version, p.arch)
+        for p in await RedHatAdvisoryAffectedProduct.filter(red_hat_advisory_id=advisory.id).all()
+    }
+
+    # Add new affected products
+    to_add = new_products - existing_products
+    if to_add:
+        logger.info(f"Adding new affected products for advisory {advisory.name}: {to_add}")
+        await RedHatAdvisoryAffectedProduct.bulk_create([
+            RedHatAdvisoryAffectedProduct(
+                red_hat_advisory_id=advisory.id,
+                variant=variant,
+                name=name,
+                major_version=major,
+                minor_version=minor,
+                arch=arch,
+            ) for (variant, name, major, minor, arch) in to_add
+        ], ignore_conflicts=True)
+    else:
+        logger.info(f"No new affected products to add for advisory {advisory.name}")
+
+    # Remove affected products not in the new set if updating
+    if update_advisory:
+        to_remove = existing_products - new_products
+        if to_remove:
+            logger.info(f"Removing affected products for advisory {advisory.name}: {to_remove}")
+            for (variant, name, major, minor, arch) in to_remove:
+                await RedHatAdvisoryAffectedProduct.filter(
+                    red_hat_advisory_id=advisory.id,
+                    variant=variant,
+                    name=name,
+                    major_version=major,
+                    minor_version=minor,
+                    arch=arch,
+                ).delete()
+        else:
+            logger.info(f"No affected products to remove for advisory {advisory.name}")
+
+
 def parse_red_hat_date(rhdate: str) -> datetime:
     return datetime.fromisoformat(rhdate.removesuffix("Z"))
 
@@ -294,7 +481,7 @@ async def process_csaf_file(json_data: dict, filepath: str) -> Optional[RedHatAd
     if not data.get("red_hat_fixed_packages"):
         logger.warning(f"No fixed packages found in CSAF document {filepath}")
         return None
-
+    update_advisory = False
     try:
         async with in_transaction():
             # Check if advisory already exists
@@ -332,6 +519,7 @@ async def process_csaf_file(json_data: dict, filepath: str) -> Optional[RedHatAd
                     for field, value in updates.items():
                         setattr(advisory, field, value)
                         await advisory.save()
+                update_advisory = True
             else:
                 # Create new advisory
                 logger.info(f"Creating new advisory {data['name']}")
@@ -349,87 +537,31 @@ async def process_csaf_file(json_data: dict, filepath: str) -> Optional[RedHatAd
 
             # Handle packages
             logger.info(f"Processing packages for advisory {advisory.name}")
-            existing_packages = set(p.nevra for p in await RedHatAdvisoryPackage.filter(
-                red_hat_advisory_id=advisory.id).all())
-            new_packages = set(data["red_hat_fixed_packages"]) - existing_packages
-            if new_packages:
-                logger.info(f"New packages for advisory {advisory.name}: {new_packages}")
-                await RedHatAdvisoryPackage.bulk_create([
-                    RedHatAdvisoryPackage(
-                        red_hat_advisory_id=advisory.id,
-                        nevra=nevra
-                    ) for nevra in new_packages
-                ], ignore_conflicts=True)
+            new_nevras = set(data["red_hat_fixed_packages"])
+            await create_or_update_advisory_packages(
+                advisory, new_nevras, update_advisory=update_advisory
+            )
 
             # Handle CVEs
             logger.info(f"Processing CVEs for advisory {advisory.name}")
-            existing_cves = set(c.cve for c in await RedHatAdvisoryCVE.filter(
-                red_hat_advisory_id=advisory.id).all())
-            logger.debug(f"Existing CVEs: {existing_cves}")
-            for cve_data in data["red_hat_cve_list"]:
-                logger.debug(f"Processing CVE data: {cve_data}")
-                cve_id, vector, score, cwe = cve_data
-                if cve_id and cve_id not in existing_cves:
-                    logger.info(f"New CVE for advisory {advisory.name}: {cve_id}")
-                    await RedHatAdvisoryCVE.create(
-                        red_hat_advisory_id=advisory.id,
-                        cve=cve_id,
-                        cvss3_scoring_vector=vector,
-                        cvss3_base_score=str(score) if score else None,
-                        cwe=cwe if cwe else None,
-                    )
-                else:
-                    logger.debug(f"No new CVE found for advisory {advisory.name}")
+            new_cve_tuples = set(tuple(cve_data) for cve_data in data["red_hat_cve_list"])
+            await create_or_update_advisory_cves(
+                advisory, new_cve_tuples, update_advisory=update_advisory
+            )
 
             # Handle Bugzilla tickets
             logger.info(f"Processing Bugzilla bugs for advisory {advisory.name}")
-            try:
-                existing_bugs = set(b.bugzilla_bug_id for b in await RedHatAdvisoryBugzillaBug.filter(
-                    red_hat_advisory_id=advisory.id).all())
-                logger.debug(f"Existing Bugzilla bugs: {existing_bugs}")
-                new_bugs = set(data["red_hat_bugzilla_list"]) - existing_bugs
-
-                if new_bugs:
-                    logger.info(f"New Bugzilla bugs for advisory {advisory.name}: {new_bugs}")
-                    await RedHatAdvisoryBugzillaBug.bulk_create([
-                        RedHatAdvisoryBugzillaBug(
-                            red_hat_advisory_id=advisory.id,
-                            bugzilla_bug_id=bug_id,
-                            description=""  # No description available in CSAF data
-                        ) for bug_id in new_bugs
-                    ], ignore_conflicts=True)
-                else:
-                    logger.debug(f"No new Bugzilla bugs found for advisory {advisory.name}")
-            except Exception as e:
-                logger.error(f"Error processing Bugzilla bugs for advisory {advisory.name}: {str(e)}")
-                raise
+            new_bug_ids = set(data["red_hat_bugzilla_list"])
+            await create_or_update_advisory_bugzilla_bugs(
+                advisory, new_bug_ids, update_advisory=update_advisory
+            )
 
             # Handle affected products
             logger.info(f"Processing affected products for advisory {advisory.name}")
-            existing_products = set()
-            for prod in await RedHatAdvisoryAffectedProduct.filter(red_hat_advisory_id=advisory.id).all():
-                existing_products.add((prod.variant, prod.name, prod.major_version, prod.minor_version, prod.arch))
-
-            new_products = []
-            for product_data in data["red_hat_affected_products"]:
-                logger.debug(f"Processing affected product data: {product_data}")
-                if product_data not in existing_products:
-                    variant, name, major, minor, arch = product_data
-                    new_products.append(
-                        RedHatAdvisoryAffectedProduct(
-                            red_hat_advisory_id=advisory.id,
-                            variant=variant,
-                            name=name,
-                            major_version=major,
-                            minor_version=minor,
-                            arch=arch
-                        )
-                    )
-            if new_products:
-                logger.info(f"Adding {len(new_products)} new affected products for advisory {advisory.name}")
-                await RedHatAdvisoryAffectedProduct.bulk_create(new_products, ignore_conflicts=True)
-            else:
-                logger.debug(f"No new affected products found for advisory {advisory.name}")
+            new_products = set(data["red_hat_affected_products"])
+            await create_or_update_advisory_affected_products(
+                advisory, new_products, update_advisory=update_advisory
+            )
     except Exception as e:
         logger.error(f"Error in transaction: {str(e)}")
         raise


### PR DESCRIPTION
# Changes
Introduces new helper functions for both `RHMatcher` and `PollRHCSAFAdvisoriesWorkflow` which handle adding and removing associated advisory information from both Red Hat advisories and their cloned Rocky counterparts.



# Testing

```
$ personal_work_dir/phase3_tester.sh

========================================
  Testing Updates for Updates to rh_matcher
========================================

--- Truncate all tables in the database... ---
NOTICE:  truncate cascades to table "advisories"
NOTICE:  truncate cascades to table "red_hat_advisory_affected_products"
NOTICE:  truncate cascades to table "red_hat_advisory_bugzilla_bugs"
NOTICE:  truncate cascades to table "red_hat_advisory_cves"
NOTICE:  truncate cascades to table "red_hat_advisory_packages"
NOTICE:  truncate cascades to table "supported_products_rh_blocks"
NOTICE:  truncate cascades to table "supported_products_rpm_rh_overrides"
NOTICE:  truncate cascades to table "advisory_affected_products"
NOTICE:  truncate cascades to table "advisory_cves"
NOTICE:  truncate cascades to table "advisory_fixes"
NOTICE:  truncate cascades to table "advisory_packages"
TRUNCATE TABLE

--- Reset the red_hat_index_state table... ---
UPDATE 1

--- Restart each worker/server ---
Restarting tmux session 'apollo-server'...
Restarting tmux session 'rhworker'...
Restarting tmux session 'rpmworker'...

--- Kicking off Temporal workflow to populate the Red Hat advisories... ---
Starting workflow: PollRHCSAFAdvisoriesWorkflow on task queue: v2-rhworker
Running execution:
  WorkflowId  788b8808-4b18-4ead-a2b5-48b6a5aa9d94
  RunId       01975bb6-be00-7265-97a1-b27377cb3f7d
  Type        PollRHCSAFAdvisoriesWorkflow
  Namespace   default
  TaskQueue   v2-rhworker
📡 Monitoring workflow with ID: 788b8808-4b18-4ead-a2b5-48b6a5aa9d94...
Workflow status: COMPLETED
✅ PollRHCSAFAdvisoriesWorkflow completed successfully.
Starting workflow: RhMatcherWorkflow on task queue: v2-rpmworker
Running execution:
  WorkflowId  ff00835c-44a4-474a-9558-9172b981ec5d
  RunId       01975bb7-a178-7ce8-aa48-ebe91b844a47
  Type        RhMatcherWorkflow
  Namespace   default
  TaskQueue   v2-rpmworker
📡 Monitoring workflow with ID: ff00835c-44a4-474a-9558-9172b981ec5d...
Workflow status: COMPLETED
✅ RhMatcherWorkflow completed successfully.

--- Deleting some data for RHSA-2025:8292... ---
Delete two packages
DELETE 2
Delete two CVEs
DELETE 2
Delete two Bugzilla bugs
DELETE 2
Starting workflow: RhMatcherWorkflow on task queue: v2-rpmworker
Running execution:
  WorkflowId  faad8e74-e558-4044-8429-a6e5feeb78d3
  RunId       01975bba-340d-70c2-9885-427957520a74
  Type        RhMatcherWorkflow
  Namespace   default
  TaskQueue   v2-rpmworker
📡 Monitoring workflow with ID: faad8e74-e558-4044-8429-a6e5feeb78d3...
Workflow status: COMPLETED
✅ RhMatcherWorkflow completed successfully.

--- Reviewing RHMatcher log for add/remove actions on RHSA-2025:8292 after manual deletions ---
(expecting to see removal entries for deleted items)
[apollorpmworker:INFO:2025-06-10 15:23:23,418] Adding 14 new packages to advisory RLSA-2025:8292
[apollorpmworker:INFO:2025-06-10 15:23:23,419] Adding 10 new CVEs to advisory RLSA-2025:8292
[apollorpmworker:INFO:2025-06-10 15:23:23,420] Adding 10 new fixes to advisory RLSA-2025:8292
[apollorpmworker:INFO:2025-06-10 15:23:23,421] Adding 2 new affected products to advisory RLSA-2025:8292
[apollorpmworker:INFO:2025-06-10 15:26:09,338] Removing 2 packages from advisory RLSA-2025:8292
[apollorpmworker:INFO:2025-06-10 15:26:09,339] Removing 2 CVEs from advisory RLSA-2025:8292
[apollorpmworker:INFO:2025-06-10 15:26:09,340] Removing 2 fixes from advisory RLSA-2025:8292


========================================
  Testing Updates to poll_rh_activites workflow
========================================

--- Inserting dummy data for RHSA-2025:829 ---
Inserting dummy RPMS for RHSA-2025:8292...
INSERT 0 1
Inserting dummy CVEs for RHSA-2025:8292...
INSERT 0 1
Inserting dummy Bugzillas for RHSA-2025:8292...
INSERT 0 1
Inserting dummy affected products for RHSA-2025:8292...
INSERT 0 1
Reset the red_hat_index_state table so that the workflow will reprocess the data...
UPDATE 1
Starting workflow: PollRHCSAFAdvisoriesWorkflow on task queue: v2-rhworker
Running execution:
  WorkflowId  a31d2738-f9f7-4f35-bc9d-caf24838ca5b
  RunId       01975bbc-c6dd-75d7-b3cc-97209b70eb63
  Type        PollRHCSAFAdvisoriesWorkflow
  Namespace   default
  TaskQueue   v2-rhworker
📡 Monitoring workflow with ID: a31d2738-f9f7-4f35-bc9d-caf24838ca5b...
Workflow status: COMPLETED
✅ PollRHCSAFAdvisoriesWorkflow completed successfully.

--- Checking log for removal messages ---
[apollorhworker:INFO:2025-06-10 15:26:43,566] Removing packages for advisory RHSA-2025:8292: {'test-rpm-0:1.1-2.2.el8_10.noarch'}
[apollorhworker:INFO:2025-06-10 15:26:43,573] Removing CVEs for advisory RHSA-2025:8292: {'CVE-9999-0000'}
[apollorhworker:INFO:2025-06-10 15:26:43,579] Removing Bugzilla bugs for advisory RHSA-2025:8292: {'1234567'}
[apollorhworker:INFO:2025-06-10 15:26:43,582] Removing affected products for advisory RHSA-2025:8292: {('RHEL', 'DUMMY NAME', Decimal('99'), None, 'noarch')}

Checking database for dummy data...
 id | red_hat_advisory_id | nevra
----+---------------------+-------
(0 rows)

 id | red_hat_advisory_id | cve | cvss3_scoring_vector | cvss3_base_score | cwe
----+---------------------+-----+----------------------+------------------+-----
(0 rows)

 id | red_hat_advisory_id | bugzilla_bug_id | description
----+---------------------+-----------------+-------------
(0 rows)

 id | red_hat_advisory_id | variant | name | major_version | minor_version | arch
----+---------------------+---------+------+---------------+---------------+------
(0 rows)
```