### PR TITLE
replace PollRHAdvisoriesWorkflow with PollRHCSAFAdvisoriesWorkflow

### DIFF
--- a/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
+++ b/deploy/apollo/apollo-rhworker/templates/cronjob.yaml
@@ -35,7 +35,7 @@ spec:
               {{- range $cmd := $.Values.cron.preCommand }}
               {{ $cmd }}
               {{- end }}
-              tctl wf run --tq v2-rhworker --wt PollRHAdvisoriesWorkflow
+              tctl wf run --tq v2-rhworker --wt PollRHCSAFAdvisoriesWorkflow
               {{- range $cmd := $.Values.cron.postCommand }}
               {{ $cmd }}
               {{- end }}

--- a/deploy/apollo/apollo-rhworker/values.yaml
+++ b/deploy/apollo/apollo-rhworker/values.yaml
@@ -82,7 +82,7 @@ autoscaling:
 
 cron:
   enabled: true
-  schedule: "*/15 * * * *"
+  schedule: "0 * * * *"
   preCommand:
     - trap 'curl --max-time 2 -s -f -XPOST http://127.0.0.1:15020/quitquitquit' EXIT
     - while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done


### PR DESCRIPTION
Use the new PollRHCSAFAdvisoriesWorkflow. Reduce the frequency of runs to account for possibility of Red Hat modifying a large number of files all at once. This should reduce the chance of concurrent runs.