### PR TITLE
fix nevra parser to handle non RHEL dist tags

### DIFF
--- a/apollo/rpm_helpers/__init__.py
+++ b/apollo/rpm_helpers/__init__.py
@@ -16,7 +16,7 @@ def parse_dist_version(release: str) -> dict:
     # 3. el{major} - for regular packages without minor version
     pattern = r"""
         (?:module\+)?     # Optional module prefix
-        (?:el|rhel)       # Distribution identifier
+        (?:el|rhel|sles)  # Distribution identifier
         (\d+)             # Major version (capture group 1)
         (?:[\._]          # Separator (dot or underscore)
         (\d+))?          # Optional minor version (capture group 2)
@@ -78,19 +78,19 @@ def parse_nevra(nevra_str: str) -> dict:
     try:
         rest, arch = nevra_str.rsplit('.', 1)
     except ValueError:
-        raise ValueError("Missing architecture in NEVRA string")
+        raise ValueError(f"Missing architecture in NEVRA string {nevra_str}")
 
     # Split off release
     try:
         nvr, release = rest.rsplit('-', 1)
     except ValueError:
-        raise ValueError("Missing release in NEVRA string")
+        raise ValueError(f"Missing release in NEVRA string {nevra_str}")
 
     # Split off version
     try:
         name_version, version = nvr.rsplit('-', 1)
     except ValueError:
-        raise ValueError("Missing version in NEVRA string")
+        raise ValueError(f"Missing version in NEVRA string {nevra_str}")
 
     # Split epoch if present (it will be in the version part)
     if ':' in version:
@@ -101,7 +101,7 @@ def parse_nevra(nevra_str: str) -> dict:
     name = name_version
     dist_version = parse_dist_version(release)
     if dist_version["major"] is None:
-        raise ValueError("Invalid distribution version in NEVRA string")
+        raise ValueError(f"Invalid distribution version in NEVRA string {nevra_str}")
     major = dist_version["major"]
     minor = dist_version["minor"]
     return {

--- a/apollo/rpmworker/repomd.py
+++ b/apollo/rpmworker/repomd.py
@@ -43,7 +43,10 @@ def clean_nvra_pkg(matching_pkg: ET.Element) -> str:
 
 
 def clean_nvra(nvra_raw: str) -> str:
-    results = parse_nevra(nvra_raw)
+    try:
+        results = parse_nevra(nvra_raw)
+    except ValueError as e:
+        return nvra_raw, nvra_raw
     name = results["name"]
     version = results["version"]
     release = results["release"]

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -361,7 +361,11 @@ async def clone_advisory(
     # Generate dictionary of clean advisory nvras
     clean_advisory_nvras = {}
     for advisory_pkg in advisory.packages:
-        results = parse_nevra(advisory_pkg.nevra)
+        try:
+            results = parse_nevra(advisory_pkg.nevra)
+        except ValueError as e:
+            logger.warning(f"Skipping invalid NEVRA '{advisory_pkg.nevra}': {e}")
+            continue
         advisory_pkg_arch = results["arch"]
         if advisory_pkg_arch not in acceptable_arches:
             continue
@@ -691,7 +695,11 @@ async def process_repomd(
             # cleaned will strip out module specific info from a package name
             # and prepend 'module.' to the name for modular packages.
             cleaned, raw = repomd.clean_nvra(advisory_pkg.nevra)
-            results = parse_nevra(advisory_pkg.nevra)
+            try:
+                results = parse_nevra(advisory_pkg.nevra)
+            except ValueError as e:
+                logger.warning(f"Skipping invalid NEVRA '{advisory_pkg.nevra}': {e}")
+                continue
             name = results["name"]
             if cleaned not in clean_advisory_nvras:
                 if not cleaned in raw_pkg_nvras:


### PR DESCRIPTION
A bug was discovered when trying to run the latest RhMatcher workflow in production. See this issue: https://git.resf.org/infrastructure/meta/issues/97

This PR addresses the bug seen. When running the RhMatcher workflow in my dev environment with RH data populated directly from the CSAF files I never encountered this issue. However, the production DB has more data in it that what I was testing against including NEVRA strings in that were incompatible with the changes I'd made. When I loaded a partial dump of the production data into my dev environment i was then able to reproduce and locate where the issues was coming from. After fixing, I reloaded that production dump and then re-ran the RhMatcher workflow to confirm it succeeded.