### PR TITLE
Fixing bug in updateinfo.xml generation to include i686 packages in x86_64

### DIFF
--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -273,9 +273,9 @@ async def get_updateinfo(
                 if p_name not in pkg_src_rpm:
                     continue
                 if arch != product_arch and arch != "noarch":
-                    if arch != "x86_64":
+                    if product_arch != "x86_64":
                         continue
-                    if arch == "x86_64" and product_arch != "i686":
+                    if product_arch == "x86_64" and arch != "i686":
                         continue
 
                 skip = False


### PR DESCRIPTION
Pushing a test fix for the architecture issue with updateinfo.xml. 