### PR TITLE
Fixing bug in updateinfo.xml generation to include i686 packages in x86_64

### DIFF
--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -273,9 +273,9 @@ async def get_updateinfo(
                 if p_name not in pkg_src_rpm:
                     continue
                 if arch != product_arch and arch != "noarch":
-                    if arch != "x86_64":
+                    if product_arch != "x86_64":
                         continue
-                    if arch == "x86_64" and product_arch != "i686":
+                    if product_arch == "x86_64" and arch != "i686":
                         continue
 
                 skip = False


### PR DESCRIPTION
This patch should fix updateinfo.xml files for x86_64 arch to include i686 package versions that are in the errata files. 

The current logic was using the package arch rather than the advisory arch for comparison.  This makes the switch. 

It was tested on CIQ's test version of Apollo.  The following is a snip of the updateinfo.xml from that version with the patch applied:

```
        <package name="openssl-libs" arch="i686" epoch="1" version="1.1.1k" release="7.el8_6" src="openssl-1.1.1k-7.el8_6.src.rpm">
          <filename>openssl-libs-1.1.1k-7.el8_6.i686.rpm</filename>
          <sum type="sha256">cda7081b9bf90c3c94cad77649b4cfe2383d6d58546b97e0b7dd8ea8a987960a</sum>
        </package>
        <package name="openssl-libs" arch="x86_64" epoch="1" version="1.1.1k" release="7.el8_6" src="openssl-1.1.1k-7.el8_6.src.rpm">
          <filename>openssl-libs-1.1.1k-7.el8_6.x86_64.rpm</filename>
          <sum type="sha256">656d9fbf8647a3114dd94fca70bd29c0ae6b0115ee2536a6240910792ce731f4</sum>
        </package>
```