### PR TITLE
Bugfix/modular package extraction

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
         bazel test //apollo/tests:test_auth --test_output=all
         bazel test //apollo/tests:test_validation --test_output=all
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
+        bazel test //apollo/tests:test_api_osv --test_output=all
 
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
         bazel test //apollo/tests:test_validation --test_output=all
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
         bazel test //apollo/tests:test_api_osv --test_output=all
+        bazel test //apollo/tests:test_database_service --test_output=all
 
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -4,8 +4,6 @@ import json
 from common.logger import Logger
 from apollo.rpm_helpers import parse_nevra
 
-# Initialize Info before Logger for this module
-
 logger = Logger()
 
 EUS_CPE_PRODUCTS = frozenset([
@@ -37,7 +35,6 @@ def _is_eus_product(product_name: str, cpe: str) -> bool:
     Returns:
         True if product is EUS/E4S/AUS/TUS, False otherwise
     """
-    # Check CPE product field (most reliable indicator)
     if cpe:
         parts = cpe.split(":")
         if len(parts) > 3:
@@ -45,7 +42,6 @@ def _is_eus_product(product_name: str, cpe: str) -> bool:
             if cpe_product in EUS_CPE_PRODUCTS:
                 return True
 
-    # Check product name keywords as fallback
     if product_name:
         name_lower = product_name.lower()
         for keyword in EUS_PRODUCT_NAME_KEYWORDS:
@@ -61,14 +57,12 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
     Expands 'noarch' to all main arches and maps names to user-friendly values.
     Returns a set of tuples: (variant, name, major_version, minor_version, arch)
     """
-    # Maps architecture short names to user-friendly product names
     arch_name_map = {
         "aarch64": "Red Hat Enterprise Linux for ARM 64",
         "x86_64": "Red Hat Enterprise Linux for x86_64",
         "s390x": "Red Hat Enterprise Linux for IBM z Systems",
         "ppc64le": "Red Hat Enterprise Linux for Power, little endian",
     }
-    # List of main architectures to expand 'noarch'
     main_arches = list(arch_name_map.keys())
     affected_products = set()
     product_tree = csaf.get("product_tree", {})
@@ -76,25 +70,20 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         logger.warning("No product tree found in CSAF document")
         return affected_products
 
-    # Iterate over all vendor branches in the product tree
     for vendor_branch in product_tree.get("branches", []):
-        # Find the product_family branch for RHEL
         family_branch = None
         arches = set()
         for branch in vendor_branch.get("branches", []):
             if branch.get("category") == "product_family" and branch.get("name") == "Red Hat Enterprise Linux":
                 family_branch = branch
-            # Collect all architecture branches at the same level as product_family
             elif branch.get("category") == "architecture":
                 arch = branch.get("name")
                 if arch:
                     arches.add(arch)
-        # If 'noarch' is present, expand to all main architectures
         if "noarch" in arches:
             arches = set(main_arches)
         if not family_branch:
             continue
-        # Find the product_name branch for CPE/version info
         prod_name = None
         cpe = None
         product_full_name = None
@@ -108,29 +97,24 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         if not prod_name or not cpe:
             continue
 
-        # Skip if this is an EUS product
         if _is_eus_product(product_full_name, cpe):
             logger.debug(f"Skipping EUS product: {product_full_name}")
             continue
 
-        # Parses the CPE string to extract major and minor version numbers
         # Example CPE: "cpe:/a:redhat:enterprise_linux:9::appstream"
-        parts = cpe.split(":")  # Split the CPE string by colon
+        parts = cpe.split(":")
         major = None
         minor = None
         if len(parts) > 4:
-            version = parts[4]  # The version is typically the 5th field (index 4)
+            version = parts[4]
             if version:
                 if "." in version:
-                    # If the version contains a dot, split into major and minor
                     major, minor = version.split(".", 1)
                     major = int(major)
                     minor = int(minor)
                 else:
-                    # If no dot, only major version is present
                     major = int(version)
 
-        # For each architecture, add a tuple with product info to the set
         for arch in arches:
             name = arch_name_map.get(arch)
             if name is None:
@@ -138,11 +122,11 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
                 continue
             if major:
                 affected_products.add((
-                    family_branch.get("name"),  # variant (e.g., "Red Hat Enterprise Linux")
-                    name,                        # user-friendly architecture name
-                    major,                       # major version number
-                    minor,                       # minor version number (may be None)
-                    arch                         # architecture short name
+                    family_branch.get("name"),
+                    name,
+                    major,
+                    minor,
+                    arch
                 ))
     logger.debug(f"Number of affected products: {len(affected_products)}")
     return affected_products
@@ -166,7 +150,6 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
     if not product_tree:
         return packages
 
-    # Build a map of product_id -> is_eus
     product_eus_map = {}
 
     def traverse_for_eus(branches):
@@ -174,7 +157,6 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
         for branch in branches:
             category = branch.get("category")
 
-            # Check if this is a product_name with CPE
             if category == "product_name":
                 prod = branch.get("product", {})
                 product_id = prod.get("product_id")
@@ -185,15 +167,12 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
                     is_eus = _is_eus_product(product_name, cpe)
                     product_eus_map[product_id] = is_eus
 
-            # Recurse into nested branches
             if "branches" in branch:
                 traverse_for_eus(branch["branches"])
 
-    # First pass: build EUS map
     for vendor_branch in product_tree.get("branches", []):
         traverse_for_eus(vendor_branch.get("branches", []))
 
-    # Now extract packages from product_version entries
     def extract_packages_from_branches(branches):
         """Recursively traverse to extract packages"""
         for branch in branches:
@@ -204,18 +183,14 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
                 product_id = prod.get("product_id")
                 purl = prod.get("product_identification_helper", {}).get("purl")
 
-                # Skip if no product_id
                 if not product_id:
                     continue
 
-                # Check if this is an RPM using PURL (not container or other)
                 if purl and not purl.startswith("pkg:rpm/"):
                     continue
 
-                # Skip if product is EUS (check product_id prefix)
                 # Product IDs for packages can have format: "AppStream-9.0.0.Z.E4S:package-nevra"
                 # or just "package-nevra" for packages in product_version entries
-                # We need to check if any parent product is EUS
                 skip_eus = False
                 for eus_prod_id, is_eus in product_eus_map.items():
                     if is_eus and (":" in product_id and product_id.startswith(eus_prod_id + ":")):
@@ -225,16 +200,12 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
                 if skip_eus:
                     continue
 
-                # Extract NEVRA from product_id
                 # Format: "package-epoch:version-release.arch" or "package-epoch:version-release.arch::module:stream"
-                # For modular packages, strip off the "::module:stream" suffix
                 packages.add(product_id.split("::")[0])
 
-            # Recurse
             if "branches" in branch:
                 extract_packages_from_branches(branch["branches"])
 
-    # Second pass: extract packages
     for vendor_branch in product_tree.get("branches", []):
         extract_packages_from_branches(vendor_branch.get("branches", []))
 
@@ -247,11 +218,10 @@ def red_hat_advisory_scraper(csaf: dict):
         logger.warning("No vulnerabilities found in CSAF document")
         return None
 
-    # red_hat_advisories table values
-    red_hat_issued_at = csaf["document"]["tracking"]["initial_release_date"] # "2025-02-24T03:42:46+00:00"
-    red_hat_updated_at = csaf["document"]["tracking"]["current_release_date"] # "2025-04-17T12:08:56+00:00"
-    name = csaf["document"]["tracking"]["id"] # "RHSA-2025:1234"
-    red_hat_synopsis = csaf["document"]["title"] # "Red Hat Bug Fix Advisory: Red Hat Quay v3.13.4 bug fix release"
+    red_hat_issued_at = csaf["document"]["tracking"]["initial_release_date"]
+    red_hat_updated_at = csaf["document"]["tracking"]["current_release_date"]
+    name = csaf["document"]["tracking"]["id"]
+    red_hat_synopsis = csaf["document"]["title"]
     red_hat_description = None
     topic = None
     for item in csaf["document"]["notes"]:
@@ -260,39 +230,32 @@ def red_hat_advisory_scraper(csaf: dict):
         elif item["category"] == "summary":
             topic = item["text"]
     kind_lookup = {"RHSA": "Security", "RHBA": "Bug Fix", "RHEA": "Enhancement"}
-    kind = kind_lookup[name.split("-")[0]] # "RHSA-2025:1234" --> "Security"
-    severity = csaf["document"]["aggregate_severity"]["text"] # "Important"
+    kind = kind_lookup[name.split("-")[0]]
+    severity = csaf["document"]["aggregate_severity"]["text"]
 
-    # To maintain consistency with the existing database, we need to replace the
+    # To maintain consistency with the existing database, replace
     # "Red Hat [KIND] Advisory:" prefixes with the severity level.
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Bug Fix Advisory: ", f"{severity}:")
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Security Advisory:", f"{severity}:")
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Enhancement Advisory: ", f"{severity}:")
 
-    # red_hat_advisory_packages table values
-    # Extract packages from product_tree (handles both regular and modular packages)
     red_hat_fixed_packages = _extract_packages_from_product_tree(csaf)
 
     red_hat_cve_set = set()
     red_hat_bugzilla_set = set()
 
     for vulnerability in csaf["vulnerabilities"]:
-        # red_hat_advisory_cves table values. Many older advisories do not have CVEs and so we need to handle that.
         cve_id = vulnerability.get("cve", None)
         cve_cvss3_scoring_vector = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("vectorString", None)
         cve_cvss3_base_score = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("baseScore", None)
         cve_cwe = vulnerability.get("cwe", {}).get("id", None)
         red_hat_cve_set.add((cve_id, cve_cvss3_scoring_vector, cve_cvss3_base_score, cve_cwe))
 
-        # red_hat_advisory_bugzilla_bugs table values
         for bug_id in vulnerability.get("ids", []):
             if bug_id.get("system_name") == "Red Hat Bugzilla ID":
                 red_hat_bugzilla_set.add(bug_id["text"])
 
-    # red_hat_advisory_affected_products table values
     red_hat_affected_products = extract_rhel_affected_products_for_db(csaf)
-
-    # If all products were EUS (none left after filtering), skip this advisory
     if not red_hat_affected_products:
         logger.info(f"Skipping advisory {name}: all products are EUS-only")
         return None

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -293,7 +293,7 @@ def red_hat_advisory_scraper(csaf: dict):
     red_hat_affected_products = extract_rhel_affected_products_for_db(csaf)
 
     # If all products were EUS (none left after filtering), skip this advisory
-    if len(red_hat_affected_products) == 0:
+    if not red_hat_affected_products:
         logger.info(f"Skipping advisory {name}: all products are EUS-only")
         return None
 

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -8,6 +8,38 @@ from apollo.rpm_helpers import parse_nevra
 
 logger = Logger()
 
+def _is_eus_product(product_name: str, cpe: str) -> bool:
+    """
+    Detects if a product is EUS-related based on product name and CPE.
+
+    Args:
+        product_name: Full product name (e.g., "Red Hat Enterprise Linux AppStream E4S (v.9.0)")
+        cpe: CPE string (e.g., "cpe:/a:redhat:rhel_e4s:9.0::appstream")
+
+    Returns:
+        True if product is EUS/E4S/AUS/TUS, False otherwise
+    """
+    # Check CPE product field (most reliable indicator)
+    if cpe:
+        parts = cpe.split(":")
+        if len(parts) > 3:
+            cpe_product = parts[3]
+            if cpe_product in ("rhel_eus", "rhel_e4s", "rhel_aus", "rhel_tus"):
+                return True
+
+    # Check product name keywords as fallback
+    if product_name:
+        name_lower = product_name.lower()
+        eus_keywords = ["e4s", "eus", "aus", "tus", "extended update support",
+                       "update services for sap", "advanced update support",
+                       "telecommunications update service"]
+        for keyword in eus_keywords:
+            if keyword in name_lower:
+                return True
+
+    return False
+
+
 def extract_rhel_affected_products_for_db(csaf: dict) -> set:
     """
     Extracts all needed info for red_hat_advisory_affected_products table from CSAF product_tree.
@@ -50,13 +82,20 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         # Find the product_name branch for CPE/version info
         prod_name = None
         cpe = None
+        product_full_name = None
         for branch in family_branch.get("branches", []):
             if branch.get("category") == "product_name":
                 prod = branch.get("product", {})
                 prod_name = prod.get("name")
+                product_full_name = prod.get("name")
                 cpe = prod.get("product_identification_helper", {}).get("cpe")
                 break
         if not prod_name or not cpe:
+            continue
+
+        # Skip if this is an EUS product
+        if _is_eus_product(product_full_name, cpe):
+            logger.debug(f"Skipping EUS product: {product_full_name}")
             continue
 
         # Parses the CPE string to extract major and minor version numbers
@@ -93,6 +132,106 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
     logger.debug(f"Number of affected products: {len(affected_products)}")
     return affected_products
 
+
+def _extract_packages_from_product_tree(csaf: dict) -> set:
+    """
+    Extracts fixed packages from CSAF product_tree using product_id fields.
+    Handles both regular and modular packages by extracting NEVRAs directly from product_id.
+    Filters out EUS products.
+
+    Args:
+        csaf: CSAF document dict
+
+    Returns:
+        Set of NEVRA strings
+    """
+    packages = set()
+    product_tree = csaf.get("product_tree", {})
+
+    if not product_tree:
+        return packages
+
+    # Build a map of product_id -> is_eus
+    product_eus_map = {}
+
+    def traverse_for_eus(branches):
+        """Recursively traverse to build EUS map"""
+        for branch in branches:
+            category = branch.get("category")
+
+            # Check if this is a product_name with CPE
+            if category == "product_name":
+                prod = branch.get("product", {})
+                product_id = prod.get("product_id")
+                product_name = prod.get("name", "")
+                cpe = prod.get("product_identification_helper", {}).get("cpe", "")
+
+                if product_id:
+                    is_eus = _is_eus_product(product_name, cpe)
+                    product_eus_map[product_id] = is_eus
+
+            # Recurse into nested branches
+            if "branches" in branch:
+                traverse_for_eus(branch["branches"])
+
+    # First pass: build EUS map
+    for vendor_branch in product_tree.get("branches", []):
+        traverse_for_eus(vendor_branch.get("branches", []))
+
+    # Now extract packages from product_version entries
+    def extract_packages_from_branches(branches):
+        """Recursively traverse to extract packages"""
+        for branch in branches:
+            category = branch.get("category")
+
+            if category == "product_version":
+                prod = branch.get("product", {})
+                product_id = prod.get("product_id")
+                purl = prod.get("product_identification_helper", {}).get("purl")
+
+                # Skip if no product_id
+                if not product_id:
+                    continue
+
+                # Check if this is an RPM using PURL (not container or other)
+                if purl and not purl.startswith("pkg:rpm/"):
+                    continue
+
+                # Skip if product is EUS (check product_id prefix)
+                # Product IDs for packages can have format: "AppStream-9.0.0.Z.E4S:package-nevra"
+                # or just "package-nevra" for packages in product_version entries
+                # We need to check if any parent product is EUS
+                skip_eus = False
+                for eus_prod_id, is_eus in product_eus_map.items():
+                    if is_eus and (":" in product_id and product_id.startswith(eus_prod_id + ":")):
+                        skip_eus = True
+                        break
+
+                if skip_eus:
+                    continue
+
+                # Extract NEVRA from product_id
+                # Format: "package-epoch:version-release.arch" or "package-epoch:version-release.arch::module:stream"
+                nevra = product_id
+
+                # For modular packages, strip off the "::module:stream" suffix
+                if "::" in nevra:
+                    nevra = nevra.split("::")[0]
+
+                if nevra:
+                    packages.add(nevra)
+
+            # Recurse
+            if "branches" in branch:
+                extract_packages_from_branches(branch["branches"])
+
+    # Second pass: extract packages
+    for vendor_branch in product_tree.get("branches", []):
+        extract_packages_from_branches(vendor_branch.get("branches", []))
+
+    return packages
+
+
 def red_hat_advisory_scraper(csaf: dict):
     # At the time of writing there are ~254 advisories that do not have any vulnerabilities.
     if not csaf.get("vulnerabilities"):
@@ -122,34 +261,13 @@ def red_hat_advisory_scraper(csaf: dict):
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Enhancement Advisory: ", f"{severity}:")
 
     # red_hat_advisory_packages table values
-    red_hat_fixed_packages = set()
+    # Extract packages from product_tree (handles both regular and modular packages)
+    red_hat_fixed_packages = _extract_packages_from_product_tree(csaf)
+
     red_hat_cve_set = set()
     red_hat_bugzilla_set = set()
-    product_id_suffix_list = (
-        ".aarch64",
-        ".i386",
-        ".i686",
-        ".noarch",
-        ".ppc",
-        ".ppc64",
-        ".ppc64le",
-        ".s390",
-        ".s390x",
-        ".src",
-        ".x86_64"
-    ) # TODO: find a better way to filter product IDs. This is a workaround for the fact that
-    # the product IDs in the CSAF documents also contain artifacts like container images
-    # and we only are interested in RPMs.
-    for vulnerability in csaf["vulnerabilities"]:
-        for product_id in vulnerability["product_status"]["fixed"]:
-            if product_id.endswith(product_id_suffix_list):
-                # These IDs are in the format product:package_nevra
-                # ie- AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.aarch64"
-                split_on_colon = product_id.split(":")
-                product = split_on_colon[0]
-                package_nevra = ":".join(split_on_colon[-2:])
-                red_hat_fixed_packages.add(package_nevra)
 
+    for vulnerability in csaf["vulnerabilities"]:
         # red_hat_advisory_cves table values. Many older advisories do not have CVEs and so we need to handle that.
         cve_id = vulnerability.get("cve", None)
         cve_cvss3_scoring_vector = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("vectorString", None)
@@ -164,6 +282,11 @@ def red_hat_advisory_scraper(csaf: dict):
 
     # red_hat_advisory_affected_products table values
     red_hat_affected_products = extract_rhel_affected_products_for_db(csaf)
+
+    # If all products were EUS (none left after filtering), skip this advisory
+    if len(red_hat_affected_products) == 0:
+        logger.info(f"Skipping advisory {name}: all products are EUS-only")
+        return None
 
     return {
         "red_hat_issued_at": str(red_hat_issued_at),

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -8,6 +8,24 @@ from apollo.rpm_helpers import parse_nevra
 
 logger = Logger()
 
+EUS_CPE_PRODUCTS = frozenset([
+    "rhel_eus",  # Extended Update Support
+    "rhel_e4s",  # Update Services for SAP Solutions
+    "rhel_aus",  # Advanced Update Support (IBM Power)
+    "rhel_tus",  # Telecommunications Update Service
+])
+
+EUS_PRODUCT_NAME_KEYWORDS = frozenset([
+    "e4s",
+    "eus",
+    "aus",
+    "tus",
+    "extended update support",
+    "update services for sap",
+    "advanced update support",
+    "telecommunications update service",
+])
+
 def _is_eus_product(product_name: str, cpe: str) -> bool:
     """
     Detects if a product is EUS-related based on product name and CPE.
@@ -24,16 +42,13 @@ def _is_eus_product(product_name: str, cpe: str) -> bool:
         parts = cpe.split(":")
         if len(parts) > 3:
             cpe_product = parts[3]
-            if cpe_product in ("rhel_eus", "rhel_e4s", "rhel_aus", "rhel_tus"):
+            if cpe_product in EUS_CPE_PRODUCTS:
                 return True
 
     # Check product name keywords as fallback
     if product_name:
         name_lower = product_name.lower()
-        eus_keywords = ["e4s", "eus", "aus", "tus", "extended update support",
-                       "update services for sap", "advanced update support",
-                       "telecommunications update service"]
-        for keyword in eus_keywords:
+        for keyword in EUS_PRODUCT_NAME_KEYWORDS:
             if keyword in name_lower:
                 return True
 

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -178,10 +178,10 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
             if category == "product_name":
                 prod = branch.get("product", {})
                 product_id = prod.get("product_id")
-                product_name = prod.get("name", "")
-                cpe = prod.get("product_identification_helper", {}).get("cpe", "")
 
                 if product_id:
+                    product_name = prod.get("name", "")
+                    cpe = prod.get("product_identification_helper", {}).get("cpe", "")
                     is_eus = _is_eus_product(product_name, cpe)
                     product_eus_map[product_id] = is_eus
 
@@ -227,14 +227,8 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
 
                 # Extract NEVRA from product_id
                 # Format: "package-epoch:version-release.arch" or "package-epoch:version-release.arch::module:stream"
-                nevra = product_id
-
                 # For modular packages, strip off the "::module:stream" suffix
-                if "::" in nevra:
-                    nevra = nevra.split("::")[0]
-
-                if nevra:
-                    packages.add(nevra)
+                packages.add(product_id.split("::")[0])
 
             # Recurse
             if "branches" in branch:

--- a/apollo/rhworker/poll_rh_activities.py
+++ b/apollo/rhworker/poll_rh_activities.py
@@ -651,8 +651,11 @@ async def process_csaf_files(from_timestamp: str = None) -> dict:
         releases = await fetch_csv_with_dates(session, base_url + "releases.csv")
         deletions = await fetch_csv_with_dates(session, base_url + "deletions.csv")
 
-        # Merge changes and releases, keeping the most recent timestamp for each advisory
-        all_advisories = {**changes, **releases}
+        # Merge changes and releases, prioritizing changes.csv for updated timestamps
+        # changes.csv contains the most recent modification time for each advisory
+        # releases.csv contains original publication dates
+        # We want changes.csv to take precedence to catch updates to existing advisories
+        all_advisories = {**releases, **changes}
         # Remove deletions
         for advisory_id in deletions:
             all_advisories.pop(advisory_id, None)

--- a/apollo/server/routes/api_osv.py
+++ b/apollo/server/routes/api_osv.py
@@ -255,14 +255,11 @@ async def get_advisories_osv(
         kind=None,
         fetch_related=True,
     )
-    count = fetch_adv[0]
     advisories = fetch_adv[1]
 
-    advisories_with_cves = [adv for adv in advisories if len(adv.cves) > 0]
-
     ui_url = await get_setting(UI_URL)
-    osv_advisories = [to_osv_advisory(ui_url, x) for x in advisories_with_cves]
-    page = create_page(osv_advisories, len(advisories_with_cves), params)
+    osv_advisories = [to_osv_advisory(ui_url, adv) for adv in advisories if adv.cves]
+    page = create_page(osv_advisories, len(osv_advisories), params)
 
     state = await RedHatIndexState.first()
     page.last_updated_at = (
@@ -294,7 +291,7 @@ async def get_advisory_osv(advisory_id: str):
         .get_or_none()
     )
 
-    if not advisory or len(advisory.cves) == 0:
+    if not advisory or not advisory.cves:
         raise HTTPException(404)
 
     ui_url = await get_setting(UI_URL)

--- a/apollo/server/routes/api_osv.py
+++ b/apollo/server/routes/api_osv.py
@@ -143,7 +143,6 @@ def to_osv_advisory(ui_url: str, advisory: Advisory) -> OSVAdvisory:
                 for pkg in affected_packages:
                     x = pkg[0]
                     nevra = pkg[1]
-                    # Only process "src" packages
                     if nevra.group(5) != "src":
                         continue
                     if x.nevra in processed_nvra:
@@ -198,11 +197,9 @@ def to_osv_advisory(ui_url: str, advisory: Advisory) -> OSVAdvisory:
     if advisory.red_hat_advisory:
         osv_credits.append(OSVCredit(name="Red Hat"))
 
-    # Calculate severity by finding the highest CVSS score
     highest_cvss_base_score = 0.0
     final_score_vector = None
     for x in advisory.cves:
-        # Convert cvss3_scoring_vector to a float
         base_score = x.cvss3_base_score
         if base_score and base_score != "UNKNOWN":
             base_score = float(base_score)
@@ -261,7 +258,6 @@ async def get_advisories_osv(
     count = fetch_adv[0]
     advisories = fetch_adv[1]
 
-    # Filter to only include advisories with CVE references
     advisories_with_cves = [adv for adv in advisories if len(adv.cves) > 0]
 
     ui_url = await get_setting(UI_URL)
@@ -298,7 +294,6 @@ async def get_advisory_osv(advisory_id: str):
         .get_or_none()
     )
 
-    # Only return advisories with CVE references
     if not advisory or len(advisory.cves) == 0:
         raise HTTPException(404)
 

--- a/apollo/server/services/database_service.py
+++ b/apollo/server/services/database_service.py
@@ -185,5 +185,5 @@ class DatabaseService:
             }
 
         except Exception as e:
-            logger.error(f"Failed to update last_indexed_at: {str(e)}")
-            raise RuntimeError(f"Failed to update timestamp: {str(e)}")
+            logger.error(f"Failed to update last_indexed_at: {e}")
+            raise RuntimeError(f"Failed to update timestamp: {e}") from e

--- a/apollo/server/templates/admin_workflows.jinja
+++ b/apollo/server/templates/admin_workflows.jinja
@@ -71,9 +71,47 @@
                     <h2 class="bx--type-productive-heading-03">Poll RH CSAF Advisories Workflow</h2>
                     <p class="bx--type-body-long-01">Polls Red Hat for new CSAF (Common Security Advisory Framework) advisories.</p>
 
-                    <form action="/admin/workflows/poll-rhcsaf/trigger" method="post" class="bx--form">
+                    <form action="/admin/workflows/poll-rhcsaf/trigger" method="post" class="bx--form" style="margin-top: 1rem;">
                         <button type="submit" class="bx--btn bx--btn--secondary">
                             Trigger Poll RHCSAF Workflow
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Update Index Timestamp Section -->
+        <div class="bx--row apollo-mt-3">
+            <div class="bx--col">
+                <div class="bx--tile">
+                    <h2 class="bx--type-productive-heading-03">Update CSAF Index Timestamp</h2>
+                    <p class="bx--type-body-long-01">Set the last_indexed_at timestamp to control which advisories are processed by the Poll RHCSAF workflow.</p>
+
+                    {% if last_indexed_exists %}
+                    <p class="bx--type-body-short-01" style="margin-top: 1rem;">
+                        <strong>Current last_indexed_at:</strong> {{ last_indexed_at }}
+                    </p>
+                    {% else %}
+                    <p class="bx--type-body-short-01" style="margin-top: 1rem; color: #da1e28;">
+                        <strong>No timestamp set</strong> - workflow will process all advisories
+                    </p>
+                    {% endif %}
+
+                    <form id="timestamp-form" action="/admin/workflows/update-index-timestamp" method="post" class="bx--form" style="margin-top: 1rem;">
+                        <div class="bx--form-item">
+                            <label for="timestamp_date" class="bx--label">
+                                Select Date (UTC timezone):
+                            </label>
+                            <input type="date" id="timestamp_date" name="timestamp_date" required class="bx--text-input apollo-width-auto apollo-max-width-12-5">
+                            <input type="hidden" id="new_timestamp" name="new_timestamp">
+                            <div class="bx--form__helper-text">
+                                The workflow will process advisories with timestamps after this date.<br>
+                                Time will be set to 00:00:00 UTC.
+                            </div>
+                        </div>
+
+                        <button type="submit" class="bx--btn bx--btn--tertiary">
+                            Update Timestamp
                         </button>
                     </form>
                 </div>
@@ -114,7 +152,7 @@
                     </div>
                 </div>
 
-                <div id="preview-results" class="apollo-mt-2 apollo-mb-2 apollo-p-2" style="display: none; border: 1px solid #ddd; border-radius: 4px; background-color: #f8f9fa;">
+                <div id="preview-results" class="apollo-mt-2 apollo-mb-2 apollo-p-2" style="display: none; border: 1px solid #ddd; border-radius: 4px; background-color: #f8f9fa; color: #161616;">
                     <!-- Preview results will be populated here -->
                 </div>
 
@@ -170,9 +208,29 @@
 </div>
 
 
-{% if reset_allowed %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    // Timestamp form handling
+    const timestampForm = document.getElementById('timestamp-form');
+    const timestampDateInput = document.getElementById('timestamp_date');
+    const timestampHiddenInput = document.getElementById('new_timestamp');
+
+    if (timestampForm && timestampDateInput && timestampHiddenInput) {
+        timestampForm.addEventListener('submit', function(e) {
+            const dateValue = timestampDateInput.value;
+            if (!dateValue) {
+                alert('Please select a date');
+                e.preventDefault();
+                return;
+            }
+            // Convert YYYY-MM-DD to ISO 8601 format with UTC timezone
+            const isoTimestamp = dateValue + 'T00:00:00+00:00';
+            timestampHiddenInput.value = isoTimestamp;
+        });
+    }
+
+    {% if reset_allowed %}
+    // Database reset form handling
     const confirmCheckbox = document.getElementById('confirm');
     const resetBtn = document.getElementById('reset-btn');
     const previewBtn = document.getElementById('preview-btn');
@@ -241,7 +299,7 @@ document.addEventListener('DOMContentLoaded', function() {
             previewResults.style.display = 'none';
         });
     }
+    {% endif %}
 });
 </script>
-{% endif %}
 {% endblock %}

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -69,3 +69,13 @@ py_test(
         "//apollo/server:server_lib",
     ],
 )
+
+py_test(
+    name = "test_database_service",
+    srcs = ["test_database_service.py"],
+    deps = [
+        "//apollo/server:server_lib",
+        "//apollo/db:db_lib",
+        "//common:common_lib",
+    ],
+)

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -61,3 +61,11 @@ py_test(
         "//apollo/server:server_lib",
     ],
 )
+
+py_test(
+    name = "test_api_osv",
+    srcs = ["test_api_osv.py"],
+    deps = [
+        "//apollo/server:server_lib",
+    ],
+)

--- a/apollo/tests/test_api_osv.py
+++ b/apollo/tests/test_api_osv.py
@@ -1,0 +1,248 @@
+"""
+Tests for OSV API CVE filtering functionality
+"""
+
+import unittest
+import datetime
+from unittest.mock import Mock
+
+from apollo.server.routes.api_osv import to_osv_advisory
+
+
+class MockSupportedProduct:
+    """Mock SupportedProduct model"""
+
+    def __init__(self, variant="Rocky Linux", vendor="Rocky Enterprise Software Foundation"):
+        self.variant = variant
+        self.vendor = vendor
+
+
+class MockSupportedProductsRhMirror:
+    """Mock SupportedProductsRhMirror model"""
+
+    def __init__(self, match_major_version=9):
+        self.match_major_version = match_major_version
+
+
+class MockPackage:
+    """Mock Package model"""
+
+    def __init__(
+        self,
+        nevra,
+        product_name="Rocky Linux 9",
+        repo_name="BaseOS",
+        supported_product=None,
+        supported_products_rh_mirror=None,
+    ):
+        self.nevra = nevra
+        self.product_name = product_name
+        self.repo_name = repo_name
+        self.supported_product = supported_product or MockSupportedProduct()
+        self.supported_products_rh_mirror = supported_products_rh_mirror
+
+
+class MockCVE:
+    """Mock CVE model"""
+
+    def __init__(
+        self,
+        cve="CVE-2024-1234",
+        cvss3_base_score="7.5",
+        cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+    ):
+        self.cve = cve
+        self.cvss3_base_score = cvss3_base_score
+        self.cvss3_scoring_vector = cvss3_scoring_vector
+
+
+class MockFix:
+    """Mock Fix model"""
+
+    def __init__(self, source="https://bugzilla.redhat.com/show_bug.cgi?id=1234567"):
+        self.source = source
+
+
+class MockAdvisory:
+    """Mock Advisory model"""
+
+    def __init__(
+        self,
+        name="RLSA-2024:1234",
+        synopsis="Important: test security update",
+        description="A security update for test package",
+        published_at=None,
+        updated_at=None,
+        packages=None,
+        cves=None,
+        fixes=None,
+        red_hat_advisory=None,
+    ):
+        self.name = name
+        self.synopsis = synopsis
+        self.description = description
+        self.published_at = published_at or datetime.datetime.now(
+            datetime.timezone.utc
+        )
+        self.updated_at = updated_at or datetime.datetime.now(datetime.timezone.utc)
+        self.packages = packages or []
+        self.cves = cves or []
+        self.fixes = fixes or []
+        self.red_hat_advisory = red_hat_advisory
+
+
+class TestOSVCVEFiltering(unittest.TestCase):
+    """Test CVE filtering logic in OSV API"""
+
+    def test_advisory_with_cve_has_upstream_references(self):
+        """Test that advisories with CVEs have upstream references populated"""
+        packages = [
+            MockPackage(
+                nevra="pcs-0:0.11.8-2.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE(cve="CVE-2024-1234")]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.upstream)
+        self.assertEqual(len(result.upstream), 1)
+        self.assertIn("CVE-2024-1234", result.upstream)
+
+    def test_advisory_with_multiple_cves(self):
+        """Test that advisories with multiple CVEs include all in upstream"""
+        packages = [
+            MockPackage(
+                nevra="openssl-1:3.0.7-28.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [
+            MockCVE(cve="CVE-2024-1111"),
+            MockCVE(cve="CVE-2024-2222"),
+            MockCVE(cve="CVE-2024-3333"),
+        ]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.upstream)
+        self.assertEqual(len(result.upstream), 3)
+        self.assertIn("CVE-2024-1111", result.upstream)
+        self.assertIn("CVE-2024-2222", result.upstream)
+        self.assertIn("CVE-2024-3333", result.upstream)
+
+    def test_advisory_without_cves_has_empty_upstream(self):
+        """Test that advisories without CVEs have empty upstream list"""
+        packages = [
+            MockPackage(
+                nevra="kernel-0:5.14.0-427.el9.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+
+        advisory = MockAdvisory(packages=packages, cves=[])
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.upstream)
+        self.assertEqual(len(result.upstream), 0)
+
+    def test_source_packages_only(self):
+        """Test that only source packages are processed, not binary packages"""
+        packages = [
+            MockPackage(
+                nevra="httpd-0:2.4.57-8.el9.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+            MockPackage(
+                nevra="httpd-0:2.4.57-8.el9.x86_64",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+            MockPackage(
+                nevra="httpd-0:2.4.57-8.el9.aarch64",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE()]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        # Should only have 1 affected package (the source package)
+        self.assertEqual(len(result.affected), 1)
+        self.assertEqual(result.affected[0].package.name, "httpd")
+
+    def test_severity_from_highest_cvss(self):
+        """Test that severity uses the highest CVSS score from multiple CVEs"""
+        packages = [
+            MockPackage(
+                nevra="vim-2:9.0.1592-1.el9.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [
+            MockCVE(
+                cve="CVE-2024-1111",
+                cvss3_base_score="5.5",
+                cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            ),
+            MockCVE(
+                cve="CVE-2024-2222",
+                cvss3_base_score="9.8",
+                cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            ),
+            MockCVE(
+                cve="CVE-2024-3333",
+                cvss3_base_score="7.5",
+                cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            ),
+        ]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.severity)
+        self.assertEqual(len(result.severity), 1)
+        self.assertEqual(result.severity[0].type, "CVSS_V3")
+        self.assertEqual(
+            result.severity[0].score, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        )
+
+    def test_ecosystem_format(self):
+        """Test that ecosystem field is formatted correctly"""
+        packages = [
+            MockPackage(
+                nevra="bash-0:5.1.8-9.el9.src",
+                product_name="Rocky Linux 9",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE()]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertEqual(len(result.affected), 1)
+        self.assertEqual(result.affected[0].package.ecosystem, "Rocky Linux:9")
+
+    def test_version_format_with_epoch(self):
+        """Test that fixed version includes epoch in epoch:version-release format"""
+        packages = [
+            MockPackage(
+                nevra="systemd-0:252-38.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE()]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        fixed_version = result.affected[0].ranges[0].events[1].fixed
+        self.assertEqual(fixed_version, "0:252-38.el9_5")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apollo/tests/test_database_service.py
+++ b/apollo/tests/test_database_service.py
@@ -1,0 +1,226 @@
+"""
+Tests for DatabaseService functionality
+Tests utility functions for database operations including timestamp management
+"""
+
+import unittest
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import Mock, AsyncMock, patch
+import os
+
+# Add the project root to the Python path
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from apollo.server.services.database_service import DatabaseService
+
+
+class TestEnvironmentDetection(unittest.TestCase):
+    """Test environment detection functionality."""
+
+    def test_is_production_when_env_is_production(self):
+        """Test production detection when ENV=production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            self.assertTrue(service.is_production_environment())
+
+    def test_is_not_production_when_env_is_development(self):
+        """Test production detection when ENV=development."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            self.assertFalse(service.is_production_environment())
+
+    def test_is_not_production_when_env_not_set(self):
+        """Test production detection when ENV is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            service = DatabaseService()
+            self.assertFalse(service.is_production_environment())
+
+    def test_is_not_production_with_staging_env(self):
+        """Test production detection with staging environment."""
+        with patch.dict(os.environ, {"ENV": "staging"}):
+            service = DatabaseService()
+            self.assertFalse(service.is_production_environment())
+
+    def test_get_environment_info_production(self):
+        """Test getting environment info for production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            result = asyncio.run(service.get_environment_info())
+
+            self.assertEqual(result["environment"], "production")
+            self.assertTrue(result["is_production"])
+            self.assertFalse(result["reset_allowed"])
+
+    def test_get_environment_info_development(self):
+        """Test getting environment info for development."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            result = asyncio.run(service.get_environment_info())
+
+            self.assertEqual(result["environment"], "development")
+            self.assertFalse(result["is_production"])
+            self.assertTrue(result["reset_allowed"])
+
+
+class TestLastIndexedAtOperations(unittest.TestCase):
+    """Test last_indexed_at timestamp operations."""
+
+    def test_get_last_indexed_at_when_exists(self):
+        """Test getting last_indexed_at when record exists."""
+        mock_index_state = Mock()
+        test_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_index_state.last_indexed_at = test_time
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state:
+            mock_state.first = AsyncMock(return_value=mock_index_state)
+
+            service = DatabaseService()
+            result = asyncio.run(service.get_last_indexed_at())
+
+            self.assertEqual(result["last_indexed_at"], test_time)
+            self.assertEqual(result["last_indexed_at_iso"], "2025-07-01T00:00:00+00:00")
+            self.assertTrue(result["exists"])
+
+    def test_get_last_indexed_at_when_not_exists(self):
+        """Test getting last_indexed_at when no record exists."""
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state:
+            mock_state.first = AsyncMock(return_value=None)
+
+            service = DatabaseService()
+            result = asyncio.run(service.get_last_indexed_at())
+
+            self.assertIsNone(result["last_indexed_at"])
+            self.assertIsNone(result["last_indexed_at_iso"])
+            self.assertFalse(result["exists"])
+
+    def test_get_last_indexed_at_when_timestamp_is_none(self):
+        """Test getting last_indexed_at when timestamp field is None."""
+        mock_index_state = Mock()
+        mock_index_state.last_indexed_at = None
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state:
+            mock_state.first = AsyncMock(return_value=mock_index_state)
+
+            service = DatabaseService()
+            result = asyncio.run(service.get_last_indexed_at())
+
+            self.assertIsNone(result["last_indexed_at"])
+            self.assertIsNone(result["last_indexed_at_iso"])
+            self.assertFalse(result["exists"])
+
+    def test_update_last_indexed_at_existing_record(self):
+        """Test updating last_indexed_at for existing record."""
+        old_time = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        new_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        mock_index_state = Mock()
+        mock_index_state.last_indexed_at = old_time
+        mock_index_state.save = AsyncMock()
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state, \
+             patch("apollo.server.services.database_service.Logger"):
+            mock_state.first = AsyncMock(return_value=mock_index_state)
+
+            service = DatabaseService()
+            result = asyncio.run(service.update_last_indexed_at(new_time, "admin@example.com"))
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["old_timestamp"], "2025-06-01T00:00:00+00:00")
+            self.assertEqual(result["new_timestamp"], "2025-07-01T00:00:00+00:00")
+            self.assertIn("Successfully updated", result["message"])
+
+            # Verify save was called
+            mock_index_state.save.assert_called_once()
+            # Verify timestamp was updated
+            self.assertEqual(mock_index_state.last_indexed_at, new_time)
+
+    def test_update_last_indexed_at_create_new_record(self):
+        """Test updating last_indexed_at when no record exists (creates new)."""
+        new_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state, \
+             patch("apollo.server.services.database_service.Logger"):
+            mock_state.first = AsyncMock(return_value=None)
+            mock_state.create = AsyncMock()
+
+            service = DatabaseService()
+            result = asyncio.run(service.update_last_indexed_at(new_time, "admin@example.com"))
+
+            self.assertTrue(result["success"])
+            self.assertIsNone(result["old_timestamp"])
+            self.assertEqual(result["new_timestamp"], "2025-07-01T00:00:00+00:00")
+            self.assertIn("Successfully updated", result["message"])
+
+            # Verify create was called with correct timestamp
+            mock_state.create.assert_called_once_with(last_indexed_at=new_time)
+
+    def test_update_last_indexed_at_handles_exception(self):
+        """Test that update_last_indexed_at handles database exceptions."""
+        new_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state, \
+             patch("apollo.server.services.database_service.Logger"):
+            mock_state.first = AsyncMock(side_effect=Exception("Database error"))
+
+            service = DatabaseService()
+
+            with self.assertRaises(RuntimeError) as cm:
+                asyncio.run(service.update_last_indexed_at(new_time, "admin@example.com"))
+
+            self.assertIn("Failed to update timestamp", str(cm.exception))
+
+
+class TestPartialResetValidation(unittest.TestCase):
+    """Test partial reset validation logic."""
+
+    def test_preview_partial_reset_blocks_in_production(self):
+        """Test that preview_partial_reset raises error in production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            cutoff_date = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.preview_partial_reset(cutoff_date))
+
+            self.assertIn("production environment", str(cm.exception))
+
+    def test_preview_partial_reset_rejects_future_date(self):
+        """Test that preview_partial_reset rejects future dates."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            future_date = datetime(2099, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.preview_partial_reset(future_date))
+
+            self.assertIn("must be in the past", str(cm.exception))
+
+    def test_perform_partial_reset_blocks_in_production(self):
+        """Test that perform_partial_reset raises error in production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            cutoff_date = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.perform_partial_reset(cutoff_date, "admin@example.com"))
+
+            self.assertIn("production environment", str(cm.exception))
+
+    def test_perform_partial_reset_rejects_future_date(self):
+        """Test that perform_partial_reset rejects future dates."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            future_date = datetime(2099, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.perform_partial_reset(future_date, "admin@example.com"))
+
+            self.assertIn("must be in the past", str(cm.exception))
+
+
+if __name__ == "__main__":
+    # Run with verbose output
+    unittest.main(verbosity=2)

--- a/apollo/tests/test_rhcsaf.py
+++ b/apollo/tests/test_rhcsaf.py
@@ -52,7 +52,29 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
                                             "product_identification_helper": {
                                                 "cpe": "cpe:/o:redhat:enterprise_linux:9.4"
                                             }
-                                        }
+                                        },
+                                        "branches": [
+                                            {
+                                                "category": "product_version",
+                                                "name": "rsync-0:3.2.3-19.el9_4.1.x86_64",
+                                                "product": {
+                                                    "product_id": "rsync-0:3.2.3-19.el9_4.1.x86_64",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/rsync@3.2.3-19.el9_4.1?arch=x86_64"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "category": "product_version",
+                                                "name": "rsync-0:3.2.3-19.el9_4.1.src",
+                                                "product": {
+                                                    "product_id": "rsync-0:3.2.3-19.el9_4.1.src",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/rsync@3.2.3-19.el9_4.1?arch=src"
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -253,3 +275,226 @@ class TestExtractRhelAffectedProducts(unittest.TestCase):
             ("Red Hat Enterprise Linux", "Red Hat Enterprise Linux for x86_64", 9, None, "x86_64"),
             result
         )
+
+
+class TestEUSDetection(unittest.TestCase):
+    """Test EUS product detection and filtering"""
+
+    def setUp(self):
+        with patch('common.logger.Logger') as mock_logger_class:
+            mock_logger_class.return_value = MagicMock()
+            from apollo.rhcsaf import _is_eus_product
+            self._is_eus_product = _is_eus_product
+
+    def test_detect_eus_via_cpe(self):
+        """Test EUS detection via CPE product field"""
+        # EUS CPE products
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_eus:9.4::appstream"))
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_e4s:9.0::appstream"))
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_aus:8.2::appstream"))
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_tus:8.8::appstream"))
+
+        # Non-EUS CPE product
+        self.assertFalse(self._is_eus_product("Some Product", "cpe:/a:redhat:enterprise_linux:9::appstream"))
+
+    def test_detect_eus_via_name(self):
+        """Test EUS detection via product name keywords"""
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream EUS (v.9.4)", ""))
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream E4S (v.9.0)", ""))
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream AUS (v.8.2)", ""))
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream TUS (v.8.8)", ""))
+
+        # Non-EUS product name
+        self.assertFalse(self._is_eus_product("Red Hat Enterprise Linux AppStream", ""))
+
+    def test_eus_filtering_in_affected_products(self):
+        """Test that EUS products are filtered from affected products"""
+        csaf = {
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux AppStream EUS (v.9.4)",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        result = extract_rhel_affected_products_for_db(csaf)
+        # Should be empty because the only product is EUS
+        self.assertEqual(len(result), 0)
+
+
+class TestModularPackages(unittest.TestCase):
+    """Test modular package extraction"""
+
+    def test_extract_modular_packages(self):
+        """Test extraction of modular packages with ::module:stream suffix"""
+        csaf = {
+            "document": {
+                "tracking": {
+                    "initial_release_date": "2025-07-28T00:00:00+00:00",
+                    "current_release_date": "2025-07-28T00:00:00+00:00",
+                    "id": "RHSA-2025:12008"
+                },
+                "title": "Red Hat Security Advisory: Important: redis:7 security update",
+                "aggregate_severity": {"text": "Important"},
+                "notes": [
+                    {"category": "general", "text": "Test description"},
+                    {"category": "summary", "text": "Test topic"}
+                ]
+            },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "name": "Red Hat Enterprise Linux 9",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux 9",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/o:redhat:enterprise_linux:9::appstream"
+                                            }
+                                        },
+                                        "branches": [
+                                            {
+                                                "category": "product_version",
+                                                "name": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.x86_64::redis:7",
+                                                "product": {
+                                                    "product_id": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.x86_64::redis:7",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/redis@7.2.10-1.module+el9.6.0+23332+115a3b01?arch=x86_64&rpmmod=redis:7:9060020250716081121:9"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "category": "product_version",
+                                                "name": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.src::redis:7",
+                                                "product": {
+                                                    "product_id": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.src::redis:7",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/redis@7.2.10-1.module+el9.6.0+23332+115a3b01?arch=src&rpmmod=redis:7:9060020250716081121:9"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2025-12345",
+                    "ids": [{"system_name": "Red Hat Bugzilla ID", "text": "123456"}],
+                    "product_status": {"fixed": []},
+                    "scores": [{"cvss_v3": {"vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "baseScore": 9.8}}],
+                    "cwe": {"id": "CWE-79"}
+                }
+            ]
+        }
+
+        result = red_hat_advisory_scraper(csaf)
+
+        # Check that modular packages were extracted with ::module:stream stripped
+        self.assertIn("redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.x86_64", result["red_hat_fixed_packages"])
+        self.assertIn("redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.src", result["red_hat_fixed_packages"])
+
+        # Verify epoch is preserved
+        for pkg in result["red_hat_fixed_packages"]:
+            if "redis" in pkg:
+                self.assertIn("0:", pkg, "Epoch should be preserved in NEVRA")
+
+
+class TestEUSAdvisoryFiltering(unittest.TestCase):
+    """Test that EUS-only advisories are filtered out"""
+
+    def test_eus_only_advisory_returns_none(self):
+        """Test that advisory with only EUS products returns None"""
+        csaf = {
+            "document": {
+                "tracking": {
+                    "initial_release_date": "2025-01-01T00:00:00+00:00",
+                    "current_release_date": "2025-01-01T00:00:00+00:00",
+                    "id": "RHSA-2025:9756"
+                },
+                "title": "Red Hat Security Advisory: Important: package security update",
+                "aggregate_severity": {"text": "Important"},
+                "notes": [
+                    {"category": "general", "text": "EUS advisory"},
+                    {"category": "summary", "text": "EUS topic"}
+                ]
+            },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "name": "Red Hat Enterprise Linux AppStream EUS (v.9.4)",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux AppStream EUS (v.9.4)",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2025-99999",
+                    "ids": [{"system_name": "Red Hat Bugzilla ID", "text": "999999"}],
+                    "product_status": {"fixed": []},
+                    "scores": [{"cvss_v3": {"vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "baseScore": 9.8}}],
+                    "cwe": {"id": "CWE-79"}
+                }
+            ]
+        }
+
+        result = red_hat_advisory_scraper(csaf)
+
+        # Advisory should be filtered out (return None) because all products are EUS
+        self.assertIsNone(result)


### PR DESCRIPTION
# Fix CSAF parser for modular packages and add EUS filtering

## Summary

This PR fixes the CSAF (Common Security Advisory Framework) parser to correctly extract modular package information and adds filtering to exclude EUS (Extended Update Support) products from advisory processing. It also fixes a bug in the CSV merge logic that was preventing advisory updates from being detected.

## Changes

**Modular Package Extraction Fix:**
- Rewrote package extraction to use `product_tree` structure instead of vulnerability product_status
- New `_extract_packages_from_product_tree()` function traverses the product tree to extract NEVRAs directly from product_id fields
- Correctly handles both regular and modular packages by extracting from product_version entries
- Strips modular suffix (::module:stream) from NEVRAs to get clean package identifiers
- Filters out non-RPM artifacts (containers, etc.) using PURL validation

**EUS Product Filtering:**
- Added `_is_eus_product()` function to detect EUS/E4S/AUS/TUS products
- Checks both CPE product field and product name keywords for reliable detection
- Filters EUS products at multiple levels:
  - During affected product extraction
  - During package extraction from product tree
- Skips advisories that only affect EUS products
- Prevents EUS-only packages from contaminating regular release repositories

**CSV Merge Fix:**
- Fixed merge order to prioritize changes.csv over releases.csv
- changes.csv contains the most recent modification timestamps for advisories
- releases.csv contains original publication dates
- Previous order was causing updated advisories to be skipped if they were already in releases.csv

**Web UI Addition:**
- Added admin interface for managing CSAF index timestamp
- Allows administrators to manually adjust the "last indexed" timestamp
- Useful for reprocessing advisories or troubleshooting ingestion issues

## Technical Details

The previous implementation extracted packages from vulnerability.product_status.fixed, which only contained regular packages. Modular packages are stored in the product_tree structure under product_version entries with format "package-nevra::module:stream". The new implementation correctly traverses this structure and extracts both package types.

EUS products are detected using CPE strings (e.g., cpe:/a:redhat:rhel_e4s:9.0) and product name keywords. These products provide extended support for specific minor versions and should not be mixed with regular releases.
