### PR TITLE
Feature/config and processing refactor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@ node_modules
 .venv
 .ijwb
 .idea
+temp
+csaf_analysis
+bazel-*
+.git
+container_data

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
         bazel test //apollo/tests:test_auth --test_output=all
         bazel test //apollo/tests:test_validation --test_output=all
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
+        bazel test //apollo/tests:test_api_osv --test_output=all
 
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
         bazel test //apollo/tests:test_csaf_processing --test_output=all
         bazel test //apollo/tests:test_api_keys --test_output=all
         bazel test //apollo/tests:test_auth --test_output=all
+        bazel test //apollo/tests:test_api_updateinfo --test_output=all
         bazel test //apollo/tests:test_validation --test_output=all
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
         bazel test //apollo/tests:test_api_osv --test_output=all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
         bazel test //apollo/tests:test_api_osv --test_output=all
         bazel test //apollo/tests:test_database_service --test_output=all
+        bazel test //apollo/tests:test_rh_matcher_activities --test_output=all
 
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
         bazel test //apollo/tests:test_validation --test_output=all
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
         bazel test //apollo/tests:test_api_osv --test_output=all
+        bazel test //apollo/tests:test_database_service --test_output=all
 
     - name: Integration Tests
       run: ./build/scripts/test.bash

--- a/apollo/db/__init__.py
+++ b/apollo/db/__init__.py
@@ -201,6 +201,7 @@ class SupportedProductsRhMirror(Model):
     match_major_version = fields.IntField()
     match_minor_version = fields.IntField(null=True)
     match_arch = fields.CharField(max_length=255)
+    active = fields.BooleanField(default=True)
 
     rpm_repomds: fields.ReverseRelation["SupportedProductsRpmRepomd"]
     rpm_rh_overrides: fields.ReverseRelation["SupportedProductsRpmRhOverride"]

--- a/apollo/db/__init__.py
+++ b/apollo/db/__init__.py
@@ -321,8 +321,8 @@ class AdvisoryPackage(Model):
 
     def __init__(self, **kwargs):
         if 'package_name' in kwargs:
-            kwargs['package_name'] = self._clean_package_name(
-                kwargs['package_name']
+            kwargs['_package_name'] = self._clean_package_name(
+                kwargs.pop('package_name')
             )
         super().__init__(**kwargs)
 

--- a/apollo/migrations/20251104111759_add_mirror_active_field.sql
+++ b/apollo/migrations/20251104111759_add_mirror_active_field.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+alter table supported_products_rh_mirrors
+add column active boolean not null default true;
+
+create index supported_products_rh_mirrors_active_idx
+on supported_products_rh_mirrors(active);
+
+
+-- migrate:down
+drop index if exists supported_products_rh_mirrors_active_idx;
+alter table supported_products_rh_mirrors drop column active;

--- a/apollo/publishing_tools/apollo_tree.py
+++ b/apollo/publishing_tools/apollo_tree.py
@@ -6,12 +6,15 @@ import asyncio
 import logging
 import hashlib
 import gzip
+import re
 from dataclasses import dataclass
 import time
 from urllib.parse import quote
 from xml.etree import ElementTree as ET
 
 import aiohttp
+
+from apollo.server.routes.api_updateinfo import PRODUCT_SLUG_MAP
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("apollo_tree")
@@ -20,6 +23,31 @@ NS = {
     "": "http://linux.duke.edu/metadata/repo",
     "rpm": "http://linux.duke.edu/metadata/rpm"
 }
+
+PRODUCT_NAME_TO_SLUG = {v: k for k, v in PRODUCT_SLUG_MAP.items()}
+
+
+def get_product_slug(product_name: str) -> str:
+    """
+    Convert product name to API slug for v2 endpoint.
+    Strips version numbers and architecture placeholders before lookup.
+
+    Examples:
+        "Rocky Linux 9 $arch" -> "Rocky Linux"
+        "Rocky Linux 10.5" -> "Rocky Linux"
+        "Rocky Linux SIG Cloud" -> "Rocky Linux SIG Cloud"
+    """
+    clean_name = product_name.replace("$arch", "").strip()
+
+    clean_name = re.sub(r'\s+\d+(\.\d+)?$', '', clean_name).strip()
+
+    slug = PRODUCT_NAME_TO_SLUG.get(clean_name)
+    if not slug:
+        raise ValueError(
+            f"Unknown product: {clean_name}. "
+            f"Valid products: {', '.join(PRODUCT_NAME_TO_SLUG.keys())}"
+        )
+    return slug
 
 
 @dataclass
@@ -142,14 +170,37 @@ async def fetch_updateinfo_from_apollo(
     repo: dict,
     product_name: str,
     api_base: str = None,
+    api_version: int = 1,
+    major_version: int = None,
+    minor_version: int = None,
 ) -> str:
-    pname_arch = product_name.replace("$arch", repo["arch"])
+    """
+    Fetch updateinfo.xml from Apollo API.
+
+    Args:
+        repo: Repository dict with 'name' and 'arch' keys
+        product_name: Product name
+        api_base: Optional API base URL override
+        api_version: 2 for new endpoint, 1 for legacy (default)
+        major_version: Required for api_version=2
+        minor_version: Optional for api_version=2
+    """
     if not api_base:
         api_base = "https://apollo.build.resf.org/api/v3/updateinfo"
-    api_url = f"{api_base}/{quote(pname_arch)}/{quote(repo['name'])}/updateinfo.xml"
-    api_url += f"?req_arch={repo['arch']}"
 
-    logger.info("Fetching updateinfo from %s", api_url)
+    if api_version == 2:
+        product_slug = get_product_slug(product_name)
+        api_url = f"{api_base}/{product_slug}/{major_version}/{quote(repo['name'])}/updateinfo.xml"
+        api_url += f"?arch={repo['arch']}"
+        if minor_version is not None:
+            api_url += f"&minor_version={minor_version}"
+        logger.info("Using v2 endpoint: %s", api_url)
+    else:
+        pname_arch = product_name.replace("$arch", repo["arch"])
+        api_url = f"{api_base}/{quote(pname_arch)}/{quote(repo['name'])}/updateinfo.xml"
+        api_url += f"?req_arch={repo['arch']}"
+        logger.info("Using legacy endpoint: %s", api_url)
+
     async with aiohttp.ClientSession() as session:
         async with session.get(api_url) as resp:
             if resp.status != 200 and resp.status != 404:
@@ -303,6 +354,10 @@ async def run_apollo_tree(
     ignore: list[str],
     ignore_arch: list[str],
     product_name: str,
+    api_version: int = 1,
+    major_version: int = None,
+    minor_version: int = None,
+    api_base: str = None,
 ):
     if manual:
         raise Exception("Manual mode not implemented yet")
@@ -320,6 +375,10 @@ async def run_apollo_tree(
                 updateinfo = await fetch_updateinfo_from_apollo(
                     repo,
                     product_name,
+                    api_base=api_base,
+                    api_version=api_version,
+                    major_version=major_version,
+                    minor_version=minor_version,
                 )
                 if not updateinfo:
                     logger.warning("No updateinfo found for %s", repo["name"])
@@ -394,12 +453,39 @@ if __name__ == "__main__":
         "-n",
         "--product-name",
         required=True,
-        help="Product name",
+        help="Product name (e.g., 'Rocky Linux', 'Rocky Linux 8 $arch')",
+    )
+    parser.add_argument(
+        "--api-version",
+        type=int,
+        choices=[2, 1],
+        default=1,
+        help="Updateinfo endpoint pattern: 1=legacy (default), 2=new major-version based",
+    )
+    parser.add_argument(
+        "--major-version",
+        type=int,
+        help="Major version (required for --api-version 2)",
+    )
+    parser.add_argument(
+        "--minor-version",
+        type=int,
+        help="Minor version filter (optional, only with --api-version 2)",
+    )
+    parser.add_argument(
+        "--api-base",
+        help="API base URL (default: https://apollo.build.resf.org/api/v3/updateinfo)",
     )
 
     p_args = parser.parse_args()
     if p_args.auto_scan and p_args.manual:
         parser.error("Cannot use --auto-scan and --manual together")
+
+    if p_args.api_version == 2 and not p_args.major_version:
+        parser.error("--major-version is required when using --api-version 2")
+
+    if p_args.minor_version and p_args.api_version != 2:
+        parser.error("--minor-version can only be used with --api-version 2")
 
     if p_args.manual and not p_args.repos:
         parser.error("Must specify repos to publish in manual mode")
@@ -416,5 +502,9 @@ if __name__ == "__main__":
             [y for x in p_args.ignore for y in x],
             [y for x in p_args.ignore_arch for y in x],
             p_args.product_name,
+            p_args.api_version,
+            p_args.major_version,
+            p_args.minor_version,
+            p_args.api_base,
         )
     )

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -4,8 +4,6 @@ import json
 from common.logger import Logger
 from apollo.rpm_helpers import parse_nevra
 
-# Initialize Info before Logger for this module
-
 logger = Logger()
 
 EUS_CPE_PRODUCTS = frozenset([
@@ -37,7 +35,6 @@ def _is_eus_product(product_name: str, cpe: str) -> bool:
     Returns:
         True if product is EUS/E4S/AUS/TUS, False otherwise
     """
-    # Check CPE product field (most reliable indicator)
     if cpe:
         parts = cpe.split(":")
         if len(parts) > 3:
@@ -45,7 +42,6 @@ def _is_eus_product(product_name: str, cpe: str) -> bool:
             if cpe_product in EUS_CPE_PRODUCTS:
                 return True
 
-    # Check product name keywords as fallback
     if product_name:
         name_lower = product_name.lower()
         for keyword in EUS_PRODUCT_NAME_KEYWORDS:
@@ -61,14 +57,12 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
     Expands 'noarch' to all main arches and maps names to user-friendly values.
     Returns a set of tuples: (variant, name, major_version, minor_version, arch)
     """
-    # Maps architecture short names to user-friendly product names
     arch_name_map = {
         "aarch64": "Red Hat Enterprise Linux for ARM 64",
         "x86_64": "Red Hat Enterprise Linux for x86_64",
         "s390x": "Red Hat Enterprise Linux for IBM z Systems",
         "ppc64le": "Red Hat Enterprise Linux for Power, little endian",
     }
-    # List of main architectures to expand 'noarch'
     main_arches = list(arch_name_map.keys())
     affected_products = set()
     product_tree = csaf.get("product_tree", {})
@@ -76,25 +70,20 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         logger.warning("No product tree found in CSAF document")
         return affected_products
 
-    # Iterate over all vendor branches in the product tree
     for vendor_branch in product_tree.get("branches", []):
-        # Find the product_family branch for RHEL
         family_branch = None
         arches = set()
         for branch in vendor_branch.get("branches", []):
             if branch.get("category") == "product_family" and branch.get("name") == "Red Hat Enterprise Linux":
                 family_branch = branch
-            # Collect all architecture branches at the same level as product_family
             elif branch.get("category") == "architecture":
                 arch = branch.get("name")
                 if arch:
                     arches.add(arch)
-        # If 'noarch' is present, expand to all main architectures
         if "noarch" in arches:
             arches = set(main_arches)
         if not family_branch:
             continue
-        # Find the product_name branch for CPE/version info
         prod_name = None
         cpe = None
         product_full_name = None
@@ -108,29 +97,24 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         if not prod_name or not cpe:
             continue
 
-        # Skip if this is an EUS product
         if _is_eus_product(product_full_name, cpe):
             logger.debug(f"Skipping EUS product: {product_full_name}")
             continue
 
-        # Parses the CPE string to extract major and minor version numbers
         # Example CPE: "cpe:/a:redhat:enterprise_linux:9::appstream"
-        parts = cpe.split(":")  # Split the CPE string by colon
+        parts = cpe.split(":")
         major = None
         minor = None
         if len(parts) > 4:
-            version = parts[4]  # The version is typically the 5th field (index 4)
+            version = parts[4]
             if version:
                 if "." in version:
-                    # If the version contains a dot, split into major and minor
                     major, minor = version.split(".", 1)
                     major = int(major)
                     minor = int(minor)
                 else:
-                    # If no dot, only major version is present
                     major = int(version)
 
-        # For each architecture, add a tuple with product info to the set
         for arch in arches:
             name = arch_name_map.get(arch)
             if name is None:
@@ -138,11 +122,11 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
                 continue
             if major:
                 affected_products.add((
-                    family_branch.get("name"),  # variant (e.g., "Red Hat Enterprise Linux")
-                    name,                        # user-friendly architecture name
-                    major,                       # major version number
-                    minor,                       # minor version number (may be None)
-                    arch                         # architecture short name
+                    family_branch.get("name"),
+                    name,
+                    major,
+                    minor,
+                    arch
                 ))
     logger.debug(f"Number of affected products: {len(affected_products)}")
     return affected_products
@@ -166,7 +150,6 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
     if not product_tree:
         return packages
 
-    # Build a map of product_id -> is_eus
     product_eus_map = {}
 
     def traverse_for_eus(branches):
@@ -174,7 +157,6 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
         for branch in branches:
             category = branch.get("category")
 
-            # Check if this is a product_name with CPE
             if category == "product_name":
                 prod = branch.get("product", {})
                 product_id = prod.get("product_id")
@@ -185,15 +167,12 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
                     is_eus = _is_eus_product(product_name, cpe)
                     product_eus_map[product_id] = is_eus
 
-            # Recurse into nested branches
             if "branches" in branch:
                 traverse_for_eus(branch["branches"])
 
-    # First pass: build EUS map
     for vendor_branch in product_tree.get("branches", []):
         traverse_for_eus(vendor_branch.get("branches", []))
 
-    # Now extract packages from product_version entries
     def extract_packages_from_branches(branches):
         """Recursively traverse to extract packages"""
         for branch in branches:
@@ -204,18 +183,14 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
                 product_id = prod.get("product_id")
                 purl = prod.get("product_identification_helper", {}).get("purl")
 
-                # Skip if no product_id
                 if not product_id:
                     continue
 
-                # Check if this is an RPM using PURL (not container or other)
                 if purl and not purl.startswith("pkg:rpm/"):
                     continue
 
-                # Skip if product is EUS (check product_id prefix)
                 # Product IDs for packages can have format: "AppStream-9.0.0.Z.E4S:package-nevra"
                 # or just "package-nevra" for packages in product_version entries
-                # We need to check if any parent product is EUS
                 skip_eus = False
                 for eus_prod_id, is_eus in product_eus_map.items():
                     if is_eus and (":" in product_id and product_id.startswith(eus_prod_id + ":")):
@@ -225,16 +200,12 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
                 if skip_eus:
                     continue
 
-                # Extract NEVRA from product_id
                 # Format: "package-epoch:version-release.arch" or "package-epoch:version-release.arch::module:stream"
-                # For modular packages, strip off the "::module:stream" suffix
                 packages.add(product_id.split("::")[0])
 
-            # Recurse
             if "branches" in branch:
                 extract_packages_from_branches(branch["branches"])
 
-    # Second pass: extract packages
     for vendor_branch in product_tree.get("branches", []):
         extract_packages_from_branches(vendor_branch.get("branches", []))
 
@@ -247,11 +218,10 @@ def red_hat_advisory_scraper(csaf: dict):
         logger.warning("No vulnerabilities found in CSAF document")
         return None
 
-    # red_hat_advisories table values
-    red_hat_issued_at = csaf["document"]["tracking"]["initial_release_date"] # "2025-02-24T03:42:46+00:00"
-    red_hat_updated_at = csaf["document"]["tracking"]["current_release_date"] # "2025-04-17T12:08:56+00:00"
-    name = csaf["document"]["tracking"]["id"] # "RHSA-2025:1234"
-    red_hat_synopsis = csaf["document"]["title"] # "Red Hat Bug Fix Advisory: Red Hat Quay v3.13.4 bug fix release"
+    red_hat_issued_at = csaf["document"]["tracking"]["initial_release_date"]
+    red_hat_updated_at = csaf["document"]["tracking"]["current_release_date"]
+    name = csaf["document"]["tracking"]["id"]
+    red_hat_synopsis = csaf["document"]["title"]
     red_hat_description = None
     topic = None
     for item in csaf["document"]["notes"]:
@@ -260,39 +230,32 @@ def red_hat_advisory_scraper(csaf: dict):
         elif item["category"] == "summary":
             topic = item["text"]
     kind_lookup = {"RHSA": "Security", "RHBA": "Bug Fix", "RHEA": "Enhancement"}
-    kind = kind_lookup[name.split("-")[0]] # "RHSA-2025:1234" --> "Security"
-    severity = csaf["document"]["aggregate_severity"]["text"] # "Important"
+    kind = kind_lookup[name.split("-")[0]]
+    severity = csaf["document"]["aggregate_severity"]["text"]
 
-    # To maintain consistency with the existing database, we need to replace the
+    # To maintain consistency with the existing database, replace
     # "Red Hat [KIND] Advisory:" prefixes with the severity level.
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Bug Fix Advisory: ", f"{severity}:")
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Security Advisory:", f"{severity}:")
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Enhancement Advisory: ", f"{severity}:")
 
-    # red_hat_advisory_packages table values
-    # Extract packages from product_tree (handles both regular and modular packages)
     red_hat_fixed_packages = _extract_packages_from_product_tree(csaf)
 
     red_hat_cve_set = set()
     red_hat_bugzilla_set = set()
 
     for vulnerability in csaf["vulnerabilities"]:
-        # red_hat_advisory_cves table values. Many older advisories do not have CVEs and so we need to handle that.
         cve_id = vulnerability.get("cve", None)
         cve_cvss3_scoring_vector = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("vectorString", None)
         cve_cvss3_base_score = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("baseScore", None)
         cve_cwe = vulnerability.get("cwe", {}).get("id", None)
         red_hat_cve_set.add((cve_id, cve_cvss3_scoring_vector, cve_cvss3_base_score, cve_cwe))
 
-        # red_hat_advisory_bugzilla_bugs table values
         for bug_id in vulnerability.get("ids", []):
             if bug_id.get("system_name") == "Red Hat Bugzilla ID":
                 red_hat_bugzilla_set.add(bug_id["text"])
 
-    # red_hat_advisory_affected_products table values
     red_hat_affected_products = extract_rhel_affected_products_for_db(csaf)
-
-    # If all products were EUS (none left after filtering), skip this advisory
     if not red_hat_affected_products:
         logger.info(f"Skipping advisory {name}: all products are EUS-only")
         return None

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -293,7 +293,7 @@ def red_hat_advisory_scraper(csaf: dict):
     red_hat_affected_products = extract_rhel_affected_products_for_db(csaf)
 
     # If all products were EUS (none left after filtering), skip this advisory
-    if len(red_hat_affected_products) == 0:
+    if not red_hat_affected_products:
         logger.info(f"Skipping advisory {name}: all products are EUS-only")
         return None
 

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -8,6 +8,38 @@ from apollo.rpm_helpers import parse_nevra
 
 logger = Logger()
 
+def _is_eus_product(product_name: str, cpe: str) -> bool:
+    """
+    Detects if a product is EUS-related based on product name and CPE.
+
+    Args:
+        product_name: Full product name (e.g., "Red Hat Enterprise Linux AppStream E4S (v.9.0)")
+        cpe: CPE string (e.g., "cpe:/a:redhat:rhel_e4s:9.0::appstream")
+
+    Returns:
+        True if product is EUS/E4S/AUS/TUS, False otherwise
+    """
+    # Check CPE product field (most reliable indicator)
+    if cpe:
+        parts = cpe.split(":")
+        if len(parts) > 3:
+            cpe_product = parts[3]
+            if cpe_product in ("rhel_eus", "rhel_e4s", "rhel_aus", "rhel_tus"):
+                return True
+
+    # Check product name keywords as fallback
+    if product_name:
+        name_lower = product_name.lower()
+        eus_keywords = ["e4s", "eus", "aus", "tus", "extended update support",
+                       "update services for sap", "advanced update support",
+                       "telecommunications update service"]
+        for keyword in eus_keywords:
+            if keyword in name_lower:
+                return True
+
+    return False
+
+
 def extract_rhel_affected_products_for_db(csaf: dict) -> set:
     """
     Extracts all needed info for red_hat_advisory_affected_products table from CSAF product_tree.
@@ -50,13 +82,20 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
         # Find the product_name branch for CPE/version info
         prod_name = None
         cpe = None
+        product_full_name = None
         for branch in family_branch.get("branches", []):
             if branch.get("category") == "product_name":
                 prod = branch.get("product", {})
                 prod_name = prod.get("name")
+                product_full_name = prod.get("name")
                 cpe = prod.get("product_identification_helper", {}).get("cpe")
                 break
         if not prod_name or not cpe:
+            continue
+
+        # Skip if this is an EUS product
+        if _is_eus_product(product_full_name, cpe):
+            logger.debug(f"Skipping EUS product: {product_full_name}")
             continue
 
         # Parses the CPE string to extract major and minor version numbers
@@ -93,6 +132,106 @@ def extract_rhel_affected_products_for_db(csaf: dict) -> set:
     logger.debug(f"Number of affected products: {len(affected_products)}")
     return affected_products
 
+
+def _extract_packages_from_product_tree(csaf: dict) -> set:
+    """
+    Extracts fixed packages from CSAF product_tree using product_id fields.
+    Handles both regular and modular packages by extracting NEVRAs directly from product_id.
+    Filters out EUS products.
+
+    Args:
+        csaf: CSAF document dict
+
+    Returns:
+        Set of NEVRA strings
+    """
+    packages = set()
+    product_tree = csaf.get("product_tree", {})
+
+    if not product_tree:
+        return packages
+
+    # Build a map of product_id -> is_eus
+    product_eus_map = {}
+
+    def traverse_for_eus(branches):
+        """Recursively traverse to build EUS map"""
+        for branch in branches:
+            category = branch.get("category")
+
+            # Check if this is a product_name with CPE
+            if category == "product_name":
+                prod = branch.get("product", {})
+                product_id = prod.get("product_id")
+                product_name = prod.get("name", "")
+                cpe = prod.get("product_identification_helper", {}).get("cpe", "")
+
+                if product_id:
+                    is_eus = _is_eus_product(product_name, cpe)
+                    product_eus_map[product_id] = is_eus
+
+            # Recurse into nested branches
+            if "branches" in branch:
+                traverse_for_eus(branch["branches"])
+
+    # First pass: build EUS map
+    for vendor_branch in product_tree.get("branches", []):
+        traverse_for_eus(vendor_branch.get("branches", []))
+
+    # Now extract packages from product_version entries
+    def extract_packages_from_branches(branches):
+        """Recursively traverse to extract packages"""
+        for branch in branches:
+            category = branch.get("category")
+
+            if category == "product_version":
+                prod = branch.get("product", {})
+                product_id = prod.get("product_id")
+                purl = prod.get("product_identification_helper", {}).get("purl")
+
+                # Skip if no product_id
+                if not product_id:
+                    continue
+
+                # Check if this is an RPM using PURL (not container or other)
+                if purl and not purl.startswith("pkg:rpm/"):
+                    continue
+
+                # Skip if product is EUS (check product_id prefix)
+                # Product IDs for packages can have format: "AppStream-9.0.0.Z.E4S:package-nevra"
+                # or just "package-nevra" for packages in product_version entries
+                # We need to check if any parent product is EUS
+                skip_eus = False
+                for eus_prod_id, is_eus in product_eus_map.items():
+                    if is_eus and (":" in product_id and product_id.startswith(eus_prod_id + ":")):
+                        skip_eus = True
+                        break
+
+                if skip_eus:
+                    continue
+
+                # Extract NEVRA from product_id
+                # Format: "package-epoch:version-release.arch" or "package-epoch:version-release.arch::module:stream"
+                nevra = product_id
+
+                # For modular packages, strip off the "::module:stream" suffix
+                if "::" in nevra:
+                    nevra = nevra.split("::")[0]
+
+                if nevra:
+                    packages.add(nevra)
+
+            # Recurse
+            if "branches" in branch:
+                extract_packages_from_branches(branch["branches"])
+
+    # Second pass: extract packages
+    for vendor_branch in product_tree.get("branches", []):
+        extract_packages_from_branches(vendor_branch.get("branches", []))
+
+    return packages
+
+
 def red_hat_advisory_scraper(csaf: dict):
     # At the time of writing there are ~254 advisories that do not have any vulnerabilities.
     if not csaf.get("vulnerabilities"):
@@ -122,34 +261,13 @@ def red_hat_advisory_scraper(csaf: dict):
     red_hat_synopsis = red_hat_synopsis.replace("Red Hat Enhancement Advisory: ", f"{severity}:")
 
     # red_hat_advisory_packages table values
-    red_hat_fixed_packages = set()
+    # Extract packages from product_tree (handles both regular and modular packages)
+    red_hat_fixed_packages = _extract_packages_from_product_tree(csaf)
+
     red_hat_cve_set = set()
     red_hat_bugzilla_set = set()
-    product_id_suffix_list = (
-        ".aarch64",
-        ".i386",
-        ".i686",
-        ".noarch",
-        ".ppc",
-        ".ppc64",
-        ".ppc64le",
-        ".s390",
-        ".s390x",
-        ".src",
-        ".x86_64"
-    ) # TODO: find a better way to filter product IDs. This is a workaround for the fact that
-    # the product IDs in the CSAF documents also contain artifacts like container images
-    # and we only are interested in RPMs.
-    for vulnerability in csaf["vulnerabilities"]:
-        for product_id in vulnerability["product_status"]["fixed"]:
-            if product_id.endswith(product_id_suffix_list):
-                # These IDs are in the format product:package_nevra
-                # ie- AppStream-9.4.0.Z.EUS:rsync-0:3.2.3-19.el9_4.1.aarch64"
-                split_on_colon = product_id.split(":")
-                product = split_on_colon[0]
-                package_nevra = ":".join(split_on_colon[-2:])
-                red_hat_fixed_packages.add(package_nevra)
 
+    for vulnerability in csaf["vulnerabilities"]:
         # red_hat_advisory_cves table values. Many older advisories do not have CVEs and so we need to handle that.
         cve_id = vulnerability.get("cve", None)
         cve_cvss3_scoring_vector = vulnerability.get("scores", [{}])[0].get("cvss_v3", {}).get("vectorString", None)
@@ -164,6 +282,11 @@ def red_hat_advisory_scraper(csaf: dict):
 
     # red_hat_advisory_affected_products table values
     red_hat_affected_products = extract_rhel_affected_products_for_db(csaf)
+
+    # If all products were EUS (none left after filtering), skip this advisory
+    if len(red_hat_affected_products) == 0:
+        logger.info(f"Skipping advisory {name}: all products are EUS-only")
+        return None
 
     return {
         "red_hat_issued_at": str(red_hat_issued_at),

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -8,6 +8,24 @@ from apollo.rpm_helpers import parse_nevra
 
 logger = Logger()
 
+EUS_CPE_PRODUCTS = frozenset([
+    "rhel_eus",  # Extended Update Support
+    "rhel_e4s",  # Update Services for SAP Solutions
+    "rhel_aus",  # Advanced Update Support (IBM Power)
+    "rhel_tus",  # Telecommunications Update Service
+])
+
+EUS_PRODUCT_NAME_KEYWORDS = frozenset([
+    "e4s",
+    "eus",
+    "aus",
+    "tus",
+    "extended update support",
+    "update services for sap",
+    "advanced update support",
+    "telecommunications update service",
+])
+
 def _is_eus_product(product_name: str, cpe: str) -> bool:
     """
     Detects if a product is EUS-related based on product name and CPE.
@@ -24,16 +42,13 @@ def _is_eus_product(product_name: str, cpe: str) -> bool:
         parts = cpe.split(":")
         if len(parts) > 3:
             cpe_product = parts[3]
-            if cpe_product in ("rhel_eus", "rhel_e4s", "rhel_aus", "rhel_tus"):
+            if cpe_product in EUS_CPE_PRODUCTS:
                 return True
 
     # Check product name keywords as fallback
     if product_name:
         name_lower = product_name.lower()
-        eus_keywords = ["e4s", "eus", "aus", "tus", "extended update support",
-                       "update services for sap", "advanced update support",
-                       "telecommunications update service"]
-        for keyword in eus_keywords:
+        for keyword in EUS_PRODUCT_NAME_KEYWORDS:
             if keyword in name_lower:
                 return True
 

--- a/apollo/rhcsaf/__init__.py
+++ b/apollo/rhcsaf/__init__.py
@@ -178,10 +178,10 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
             if category == "product_name":
                 prod = branch.get("product", {})
                 product_id = prod.get("product_id")
-                product_name = prod.get("name", "")
-                cpe = prod.get("product_identification_helper", {}).get("cpe", "")
 
                 if product_id:
+                    product_name = prod.get("name", "")
+                    cpe = prod.get("product_identification_helper", {}).get("cpe", "")
                     is_eus = _is_eus_product(product_name, cpe)
                     product_eus_map[product_id] = is_eus
 
@@ -227,14 +227,8 @@ def _extract_packages_from_product_tree(csaf: dict) -> set:
 
                 # Extract NEVRA from product_id
                 # Format: "package-epoch:version-release.arch" or "package-epoch:version-release.arch::module:stream"
-                nevra = product_id
-
                 # For modular packages, strip off the "::module:stream" suffix
-                if "::" in nevra:
-                    nevra = nevra.split("::")[0]
-
-                if nevra:
-                    packages.add(nevra)
+                packages.add(product_id.split("::")[0])
 
             # Recurse
             if "branches" in branch:

--- a/apollo/rhworker/poll_rh_activities.py
+++ b/apollo/rhworker/poll_rh_activities.py
@@ -651,8 +651,11 @@ async def process_csaf_files(from_timestamp: str = None) -> dict:
         releases = await fetch_csv_with_dates(session, base_url + "releases.csv")
         deletions = await fetch_csv_with_dates(session, base_url + "deletions.csv")
 
-        # Merge changes and releases, keeping the most recent timestamp for each advisory
-        all_advisories = {**changes, **releases}
+        # Merge changes and releases, prioritizing changes.csv for updated timestamps
+        # changes.csv contains the most recent modification time for each advisory
+        # releases.csv contains original publication dates
+        # We want changes.csv to take precedence to catch updates to existing advisories
+        all_advisories = {**releases, **changes}
         # Remove deletions
         for advisory_id in deletions:
             all_advisories.pop(advisory_id, None)

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -277,7 +277,7 @@ async def get_supported_products_with_rh_mirrors(filter_major_versions: Optional
     Filtering now happens at the mirror level within match_rh_repos activity.
     """
     logger = Logger()
-    rh_mirrors = await SupportedProductsRhMirror.all().prefetch_related(
+    rh_mirrors = await SupportedProductsRhMirror.filter(active=True).prefetch_related(
         "rpm_repomds",
     )
     ret = []
@@ -841,7 +841,8 @@ async def block_remaining_rh_advisories(supported_product_id: int) -> None:
     ).first().prefetch_related("rh_mirrors")
     for mirror in supported_product.rh_mirrors:
         mirrors = await SupportedProductsRhMirror.filter(
-            supported_product_id=supported_product_id
+            supported_product_id=supported_product_id,
+            active=True
         )
         for mirror in mirrors:
             advisories = await get_matching_rh_advisories(mirror)

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -790,6 +790,10 @@ async def match_rh_repos(params) -> None:
     all_advisories = {}
 
     for mirror in supported_product.rh_mirrors:
+        # Skip inactive mirrors
+        if not mirror.active:
+            logger.debug(f"Skipping inactive mirror {mirror.name}")
+            continue
         # Apply major version filtering if specified
         if filter_major_versions is not None and int(mirror.match_major_version) not in filter_major_versions:
             logger.debug(f"Skipping mirror {mirror.name} with major version {mirror.match_major_version} due to filtering")

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -495,14 +495,24 @@ async def clone_advisory(
                     "{http://linux.duke.edu/metadata/common}format"
                 ).find("{http://linux.duke.edu/metadata/rpm}sourcerpm")
 
-                # This means we're checking a source RPM
+                package_name = None
                 if advisory_nvra.endswith(".src.rpm"
                                          ) or advisory_nvra.endswith(".src"):
                     source_nvra = repomd.NVRA_RE.search(advisory_nvra)
-                    package_name = source_nvra.group(1)
-                else:
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+                elif source_rpm is not None and source_rpm.text:
                     source_nvra = repomd.NVRA_RE.search(source_rpm.text)
-                    package_name = source_nvra.group(1)
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+
+                if not package_name:
+                    logger.warning(
+                        "Could not extract package_name for %s in advisory %s, skipping package",
+                        nevra,
+                        advisory.name,
+                    )
+                    continue
 
                 checksum_tree = pkg.find(
                     "{http://linux.duke.edu/metadata/common}checksum"

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -790,7 +790,6 @@ async def match_rh_repos(params) -> None:
     all_advisories = {}
 
     for mirror in supported_product.rh_mirrors:
-        # Skip inactive mirrors
         if not mirror.active:
             logger.debug(f"Skipping inactive mirror {mirror.name}")
             continue

--- a/apollo/schema.sql
+++ b/apollo/schema.sql
@@ -623,7 +623,8 @@ CREATE TABLE public.supported_products_rh_mirrors (
     match_variant text NOT NULL,
     match_major_version numeric NOT NULL,
     match_minor_version numeric,
-    match_arch text NOT NULL
+    match_arch text NOT NULL,
+    active boolean DEFAULT true NOT NULL
 );
 
 
@@ -1505,6 +1506,13 @@ CREATE INDEX supported_products_rh_mirrors_match_variant_idx ON public.supported
 --
 
 CREATE INDEX supported_products_rh_mirrors_supported_product_idx ON public.supported_products_rh_mirrors USING btree (supported_product_id);
+
+
+--
+-- Name: supported_products_rh_mirrors_active_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX supported_products_rh_mirrors_active_idx ON public.supported_products_rh_mirrors USING btree (active);
 
 
 --

--- a/apollo/server/routes/admin_supported_products.py
+++ b/apollo/server/routes/admin_supported_products.py
@@ -497,10 +497,8 @@ async def admin_supported_product_mirror_new_post(
 
     # Parse form data to get the active field
     form_data_raw = await request.form()
-    # When checkbox is checked: active will be ["false", "true"], take the last value
-    # When checkbox is unchecked: active will be ["false"], take that value
-    active_values = form_data_raw.getlist("active")
-    active_value = active_values[-1] if active_values else "false"
+    # Checkbox sends "true" when checked, nothing when unchecked
+    active_value = "true" if "true" in form_data_raw.getlist("active") else "false"
 
     # Validation using centralized validation utility
     form_data = {
@@ -602,10 +600,8 @@ async def admin_supported_product_mirror_post(
 
     # Parse form data to get the active field
     form_data = await request.form()
-    # When checkbox is checked: active will be ["false", "true"], take the last value
-    # When checkbox is unchecked: active will be ["false"], take that value
-    active_values = form_data.getlist("active")
-    active_value = active_values[-1] if active_values else "false"
+    # Checkbox sends "true" when checked, nothing when unchecked
+    active_value = "true" if "true" in form_data.getlist("active") else "false"
 
     # Validation using centralized validation utility
     try:

--- a/apollo/server/routes/admin_supported_products.py
+++ b/apollo/server/routes/admin_supported_products.py
@@ -1296,6 +1296,10 @@ async def _get_mirror_config_data(mirror: SupportedProductsRhMirror) -> Dict[str
 def _json_serializer(obj):
     """Custom JSON serializer for non-standard types"""
     if isinstance(obj, Decimal):
+        # Convert Decimal to int for version numbers (which should be integers)
+        # Check if it's a whole number to preserve integer type
+        if obj % 1 == 0:
+            return int(obj)
         return float(obj)
     raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
 

--- a/apollo/server/routes/admin_supported_products.py
+++ b/apollo/server/routes/admin_supported_products.py
@@ -801,16 +801,9 @@ async def admin_supported_product_mirror_repomd_new_post(
     if isinstance(mirror, Response):
         return mirror
 
-    form_data = {
-        "production": production,
-        "arch": arch,
-        "url": url,
-        "debug_url": debug_url,
-        "source_url": source_url,
-        "repo_name": repo_name,
-    }
-
-    validated_data, validation_errors = FormValidator.validate_repomd_form(form_data)
+    validated_data, validation_errors, form_data = _validate_repomd_form(
+        production, arch, url, debug_url, source_url, repo_name
+    )
 
     if validation_errors:
         return templates.TemplateResponse(
@@ -892,16 +885,9 @@ async def admin_supported_product_mirror_repomd_post(
     if isinstance(repomd, Response):
         return repomd
 
-    form_data = {
-        "production": production,
-        "arch": arch,
-        "url": url,
-        "debug_url": debug_url,
-        "source_url": source_url,
-        "repo_name": repo_name,
-    }
-
-    validated_data, validation_errors = FormValidator.validate_repomd_form(form_data)
+    validated_data, validation_errors, form_data = _validate_repomd_form(
+        production, arch, url, debug_url, source_url, repo_name
+    )
 
     if validation_errors:
         return templates.TemplateResponse(
@@ -1305,6 +1291,26 @@ async def _get_mirror_config_data(mirror: SupportedProductsRhMirror) -> Dict[str
             for repo in mirror.rpm_repomds
         ]
     }
+
+def _validate_repomd_form(
+    production: bool,
+    arch: str,
+    url: str,
+    debug_url: str,
+    source_url: str,
+    repo_name: str
+) -> Tuple[Dict[str, Any], List[str], Dict[str, Any]]:
+    """Validate repomd form data and return validated data, errors, and original form data."""
+    form_data = {
+        "production": production,
+        "arch": arch,
+        "url": url,
+        "debug_url": debug_url,
+        "source_url": source_url,
+        "repo_name": repo_name,
+    }
+    validated_data, validation_errors = FormValidator.validate_repomd_form(form_data)
+    return validated_data, validation_errors, form_data
 
 def _json_serializer(obj):
     """Custom JSON serializer for non-standard types"""

--- a/apollo/server/routes/admin_supported_products.py
+++ b/apollo/server/routes/admin_supported_products.py
@@ -479,7 +479,6 @@ async def admin_supported_product_mirror_new_post(
     match_major_version: int = Form(),
     match_minor_version: Optional[int] = Form(default=None),
     match_arch: str = Form(),
-    active: str = Form(default="true"),
 ):
     product = await get_entity_or_error_response(
         request,
@@ -490,6 +489,13 @@ async def admin_supported_product_mirror_new_post(
     if isinstance(product, Response):
         return product
 
+    # Parse form data to get the active field
+    form_data_raw = await request.form()
+    # When checkbox is checked: active will be ["false", "true"], take the last value
+    # When checkbox is unchecked: active will be ["false"], take that value
+    active_values = form_data_raw.getlist("active")
+    active_value = active_values[-1] if active_values else "false"
+
     # Validation using centralized validation utility
     form_data = {
         "name": name,
@@ -497,7 +503,7 @@ async def admin_supported_product_mirror_new_post(
         "match_major_version": match_major_version,
         "match_minor_version": match_minor_version,
         "match_arch": match_arch,
-        "active": active,
+        "active": active_value,
     }
 
     try:
@@ -527,7 +533,7 @@ async def admin_supported_product_mirror_new_post(
         match_major_version=match_major_version,
         match_minor_version=match_minor_version,
         match_arch=validated_arch,
-        active=(active == "true"),
+        active=(active_value == "true"),
     )
     await mirror.save()
 
@@ -570,7 +576,6 @@ async def admin_supported_product_mirror_post(
     match_major_version: int = Form(),
     match_minor_version: Optional[int] = Form(default=None),
     match_arch: str = Form(),
-    active: str = Form(default="true"),
 ):
     mirror = await get_entity_or_error_response(
         request,
@@ -588,6 +593,13 @@ async def admin_supported_product_mirror_post(
     )
     if isinstance(mirror, Response):
         return mirror
+
+    # Parse form data to get the active field
+    form_data = await request.form()
+    # When checkbox is checked: active will be ["false", "true"], take the last value
+    # When checkbox is unchecked: active will be ["false"], take that value
+    active_values = form_data.getlist("active")
+    active_value = active_values[-1] if active_values else "false"
 
     # Validation using centralized validation utility
     try:
@@ -614,7 +626,7 @@ async def admin_supported_product_mirror_post(
     mirror.match_major_version = match_major_version
     mirror.match_minor_version = match_minor_version
     mirror.match_arch = validated_arch
-    mirror.active = (active == "true")
+    mirror.active = (active_value == "true")
     await mirror.save()
 
     # Re-fetch the mirror with all required relations after saving

--- a/apollo/server/routes/admin_supported_products.py
+++ b/apollo/server/routes/admin_supported_products.py
@@ -273,15 +273,12 @@ async def _import_configuration(import_data: List[Dict[str, Any]], replace_exist
             continue
 
         if existing_mirror and replace_existing:
-            # Delete existing repositories
             await SupportedProductsRpmRepomd.filter(supported_products_rh_mirror=existing_mirror).delete()
             mirror = existing_mirror
-            # Update active field if provided
             mirror.active = mirror_data.get("active", True)
             await mirror.save()
             updated_count += 1
         else:
-            # Create new mirror
             mirror = SupportedProductsRhMirror(
                 supported_product=product,
                 name=mirror_data["name"],
@@ -383,12 +380,10 @@ async def admin_supported_product(request: Request, product_id: int):
     if isinstance(product, Response):
         return product
 
-    # Fetch mirrors with explicit ordering: active first, then by version (desc), then by name
     mirrors = await SupportedProductsRhMirror.filter(
         supported_product=product
     ).order_by("-active", "-match_major_version", "name").prefetch_related("rpm_repomds").all()
 
-    # Get detailed statistics for each mirror
     for mirror in mirrors:
         repomds_count = await SupportedProductsRpmRepomd.filter(
             supported_products_rh_mirror=mirror
@@ -495,12 +490,10 @@ async def admin_supported_product_mirror_new_post(
     if isinstance(product, Response):
         return product
 
-    # Parse form data to get the active field
     form_data_raw = await request.form()
     # Checkbox sends "true" when checked, nothing when unchecked
     active_value = "true" if "true" in form_data_raw.getlist("active") else "false"
 
-    # Validation using centralized validation utility
     form_data = {
         "name": name,
         "match_variant": match_variant,
@@ -598,12 +591,10 @@ async def admin_supported_product_mirror_post(
     if isinstance(mirror, Response):
         return mirror
 
-    # Parse form data to get the active field
     form_data = await request.form()
     # Checkbox sends "true" when checked, nothing when unchecked
     active_value = "true" if "true" in form_data.getlist("active") else "false"
 
-    # Validation using centralized validation utility
     try:
         validated_name = FieldValidator.validate_name(
             name,
@@ -810,7 +801,6 @@ async def admin_supported_product_mirror_repomd_new_post(
     if isinstance(mirror, Response):
         return mirror
 
-    # Validation using centralized validation utility
     form_data = {
         "production": production,
         "arch": arch,
@@ -902,7 +892,6 @@ async def admin_supported_product_mirror_repomd_post(
     if isinstance(repomd, Response):
         return repomd
 
-    # Validation using centralized validation utility
     form_data = {
         "production": production,
         "arch": arch,

--- a/apollo/server/routes/admin_supported_products.py
+++ b/apollo/server/routes/admin_supported_products.py
@@ -1296,8 +1296,6 @@ async def _get_mirror_config_data(mirror: SupportedProductsRhMirror) -> Dict[str
 def _json_serializer(obj):
     """Custom JSON serializer for non-standard types"""
     if isinstance(obj, Decimal):
-        # Convert Decimal to int for version numbers (which should be integers)
-        # Check if it's a whole number to preserve integer type
         if obj % 1 == 0:
             return int(obj)
         return float(obj)

--- a/apollo/server/routes/api_osv.py
+++ b/apollo/server/routes/api_osv.py
@@ -255,14 +255,11 @@ async def get_advisories_osv(
         kind=None,
         fetch_related=True,
     )
-    count = fetch_adv[0]
     advisories = fetch_adv[1]
 
-    advisories_with_cves = [adv for adv in advisories if len(adv.cves) > 0]
-
     ui_url = await get_setting(UI_URL)
-    osv_advisories = [to_osv_advisory(ui_url, x) for x in advisories_with_cves]
-    page = create_page(osv_advisories, len(advisories_with_cves), params)
+    osv_advisories = [to_osv_advisory(ui_url, adv) for adv in advisories if adv.cves]
+    page = create_page(osv_advisories, len(osv_advisories), params)
 
     state = await RedHatIndexState.first()
     page.last_updated_at = (
@@ -294,7 +291,7 @@ async def get_advisory_osv(advisory_id: str):
         .get_or_none()
     )
 
-    if not advisory or len(advisory.cves) == 0:
+    if not advisory or not advisory.cves:
         raise HTTPException(404)
 
     ui_url = await get_setting(UI_URL)

--- a/apollo/server/routes/api_osv.py
+++ b/apollo/server/routes/api_osv.py
@@ -143,7 +143,6 @@ def to_osv_advisory(ui_url: str, advisory: Advisory) -> OSVAdvisory:
                 for pkg in affected_packages:
                     x = pkg[0]
                     nevra = pkg[1]
-                    # Only process "src" packages
                     if nevra.group(5) != "src":
                         continue
                     if x.nevra in processed_nvra:
@@ -198,11 +197,9 @@ def to_osv_advisory(ui_url: str, advisory: Advisory) -> OSVAdvisory:
     if advisory.red_hat_advisory:
         osv_credits.append(OSVCredit(name="Red Hat"))
 
-    # Calculate severity by finding the highest CVSS score
     highest_cvss_base_score = 0.0
     final_score_vector = None
     for x in advisory.cves:
-        # Convert cvss3_scoring_vector to a float
         base_score = x.cvss3_base_score
         if base_score and base_score != "UNKNOWN":
             base_score = float(base_score)
@@ -261,7 +258,6 @@ async def get_advisories_osv(
     count = fetch_adv[0]
     advisories = fetch_adv[1]
 
-    # Filter to only include advisories with CVE references
     advisories_with_cves = [adv for adv in advisories if len(adv.cves) > 0]
 
     ui_url = await get_setting(UI_URL)
@@ -298,7 +294,6 @@ async def get_advisory_osv(advisory_id: str):
         .get_or_none()
     )
 
-    # Only return advisories with CVE references
     if not advisory or len(advisory.cves) == 0:
         raise HTTPException(404)
 

--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -29,16 +29,14 @@ def resolve_product_slug(slug: str) -> Optional[str]:
 
 def get_source_package_name(pkg) -> str:
     """
-    Extract source package name from package, handling module prefix bug.
+    Extract source package name from package for grouping with source RPM.
 
-    The package_name field may contain "module." prefix for some module packages.
-    This function strips that prefix and returns a consistent key for grouping
-    binary packages with their source RPM.
+    Returns a consistent key for grouping binary packages with their source RPM.
+    For module packages, includes module context for proper identification.
     """
-    base_name = pkg.package_name.removeprefix("module.")
     if pkg.module_name:
-        return f"{pkg.module_name}:{base_name}:{pkg.module_stream}"
-    return base_name
+        return f"{pkg.module_name}:{pkg.package_name}:{pkg.module_stream}"
+    return pkg.package_name
 
 
 def build_source_rpm_mapping(packages: list) -> dict:
@@ -69,9 +67,8 @@ def build_source_rpm_mapping(packages: list) -> dict:
             if nvra:
                 nvr_name = nvra.group(1)
                 nvr_arch = nvra.group(4)
-                base_pkg_name = pkg.package_name.removeprefix("module.")
 
-                if base_pkg_name == nvr_name and nvr_arch == "src":
+                if pkg.package_name == nvr_name and nvr_arch == "src":
                     src_rpm = nvra_no_epoch
                     if not src_rpm.endswith(".rpm"):
                         src_rpm += ".rpm"

--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -5,7 +5,8 @@ from xml.etree import ElementTree as ET
 from fastapi import APIRouter, Response
 from slugify import slugify
 
-from apollo.db import AdvisoryAffectedProduct
+from apollo.db import AdvisoryAffectedProduct, SupportedProduct
+from tortoise.exceptions import DoesNotExist
 from apollo.server.settings import COMPANY_NAME, MANAGING_EDITOR, UI_URL, get_setting
 
 from apollo.rpmworker.repomd import NEVRA_RE, NVRA_RE, EPOCH_RE
@@ -13,6 +14,328 @@ from apollo.rpmworker.repomd import NEVRA_RE, NVRA_RE, EPOCH_RE
 from common.fastapi import RenderErrorTemplateException
 
 router = APIRouter(tags=["updateinfo"])
+
+
+PRODUCT_SLUG_MAP = {
+    "rocky-linux": "Rocky Linux",
+    "rocky-linux-sig-cloud": "Rocky Linux SIG Cloud",
+}
+
+
+def resolve_product_slug(slug: str) -> Optional[str]:
+    """Convert product slug to supported_product.name"""
+    return PRODUCT_SLUG_MAP.get(slug.lower())
+
+
+def get_source_package_name(pkg) -> str:
+    """
+    Extract source package name from package, handling module prefix bug.
+
+    The package_name field may contain "module." prefix for some module packages.
+    This function strips that prefix and returns a consistent key for grouping
+    binary packages with their source RPM.
+    """
+    base_name = pkg.package_name.removeprefix("module.")
+    if pkg.module_name:
+        return f"{pkg.module_name}:{base_name}:{pkg.module_stream}"
+    return base_name
+
+
+def build_source_rpm_mapping(packages: list) -> dict:
+    """
+    Build mapping from source package name to source RPM filename.
+
+    Groups packages by source package name, then finds the source RPM
+    (arch=="src") within each group.
+
+    Returns:
+        dict: Mapping of source_package_name -> source_rpm_filename
+    """
+    pkg_name_map = {}
+    for pkg in packages:
+        name = get_source_package_name(pkg)
+        if name not in pkg_name_map:
+            pkg_name_map[name] = []
+        pkg_name_map[name].append(pkg)
+
+    pkg_src_rpm = {}
+    for name, pkgs in pkg_name_map.items():
+        if name in pkg_src_rpm:
+            continue
+
+        for pkg in pkgs:
+            nvra_no_epoch = EPOCH_RE.sub("", pkg.nevra)
+            nvra = NVRA_RE.search(nvra_no_epoch)
+            if nvra:
+                nvr_name = nvra.group(1)
+                nvr_arch = nvra.group(4)
+                base_pkg_name = pkg.package_name.removeprefix("module.")
+
+                if base_pkg_name == nvr_name and nvr_arch == "src":
+                    src_rpm = nvra_no_epoch
+                    if not src_rpm.endswith(".rpm"):
+                        src_rpm += ".rpm"
+                    pkg_src_rpm[name] = src_rpm
+                    break
+
+    return pkg_src_rpm
+
+
+def generate_updateinfo_xml(
+    affected_products: list,
+    repo_name: str,
+    product_arch: str,
+    ui_url: str,
+    managing_editor: str,
+    company_name: str,
+    supported_product_id: int = None,
+    product_name_for_packages: str = None,
+) -> str:
+    """
+    Generate updateinfo.xml from affected products.
+
+    Args:
+        affected_products: List of AdvisoryAffectedProduct records with prefetched
+                          advisory, cves, fixes, packages, supported_product
+        repo_name: Repository name for package filtering
+        product_arch: Architecture for package filtering
+        ui_url: Base URL for UI references
+        managing_editor: Editor email for XML header
+        company_name: Company name for copyright
+        supported_product_id: Optional supported_product_id for FK-based filtering (v2)
+        product_name_for_packages: Optional product_name for legacy filtering (v1)
+
+    Returns:
+        XML string in updateinfo.xml format
+
+    Note: Either supported_product_id (v2) or product_name_for_packages (v1) must be provided.
+    """
+    advisories = {}
+    for affected_product in affected_products:
+        advisory = affected_product.advisory
+        if advisory.name not in advisories:
+            advisories[advisory.name] = {
+                "advisory": advisory,
+                "arch": affected_product.arch,
+                "major_version": affected_product.major_version,
+                "minor_version": affected_product.minor_version,
+                "supported_product_name": affected_product.supported_product.name,
+            }
+
+    tree = ET.Element("updates")
+    for _, adv in advisories.items():
+        advisory = adv["advisory"]
+        adv_arch = adv["arch"]
+        major_version = adv["major_version"]
+        minor_version = adv["minor_version"]
+        supported_product_name = adv["supported_product_name"]
+
+        update = ET.SubElement(tree, "update")
+
+        update.set("from", managing_editor)
+        update.set("status", "final")
+
+        if advisory.kind == "Security":
+            update.set("type", "security")
+        elif advisory.kind == "Bug Fix":
+            update.set("type", "bugfix")
+        elif advisory.kind == "Enhancement":
+            update.set("type", "enhancement")
+
+        update.set("version", "2")
+
+        ET.SubElement(update, "id").text = advisory.name
+        ET.SubElement(update, "title").text = advisory.synopsis
+
+        time_format = "%Y-%m-%d %H:%M:%S"
+        issued = ET.SubElement(update, "issued")
+        issued.set("date", advisory.published_at.strftime(time_format))
+        updated = ET.SubElement(update, "updated")
+        updated.set("date", advisory.updated_at.strftime(time_format))
+
+        now = datetime.datetime.utcnow()
+        ET.SubElement(
+            update, "rights"
+        ).text = f"Copyright {now.year} {company_name}"
+
+        release_name = f"{supported_product_name} {major_version}"
+        if minor_version:
+            release_name += f".{minor_version}"
+        ET.SubElement(update, "release").text = release_name
+
+        ET.SubElement(update, "pushcount").text = "1"
+        ET.SubElement(update, "severity").text = advisory.severity
+        ET.SubElement(update, "summary").text = advisory.topic
+        ET.SubElement(update, "description").text = advisory.description
+        ET.SubElement(update, "solution").text = ""
+
+        references = ET.SubElement(update, "references")
+        for cve in advisory.cves:
+            reference = ET.SubElement(references, "reference")
+            reference.set(
+                "href",
+                f"https://cve.mitre.org/cgi-bin/cvename.cgi?name={cve.cve}",
+            )
+            reference.set("id", cve.cve)
+            reference.set("type", "cve")
+            reference.set("title", cve.cve)
+
+        for fix in advisory.fixes:
+            reference = ET.SubElement(references, "reference")
+            reference.set("href", fix.source)
+            reference.set("id", fix.ticket_id)
+            reference.set("type", "bugzilla")
+            reference.set("title", fix.description)
+
+        reference = ET.SubElement(references, "reference")
+        reference.set("href", f"{ui_url}/{advisory.name}")
+        reference.set("id", advisory.name)
+        reference.set("type", "self")
+        reference.set("title", advisory.name)
+
+        packages_element = ET.SubElement(update, "pkglist")
+
+        suffixes_to_skip = [
+            "-debuginfo",
+            "-debugsource",
+            "-debuginfo-common",
+            "-debugsource-common",
+        ]
+
+        if supported_product_id is not None:
+            # v2: Filter by FK (normalized relational data)
+            filtered_packages = [
+                pkg for pkg in advisory.packages
+                if pkg.supported_product_id == supported_product_id and pkg.repo_name == repo_name
+            ]
+        else:
+            # v1: Filter by product_name (legacy denormalized field)
+            filtered_packages = [
+                pkg for pkg in advisory.packages
+                if pkg.product_name == product_name_for_packages and pkg.repo_name == repo_name
+            ]
+
+        pkg_src_rpm = build_source_rpm_mapping(filtered_packages)
+
+        collections = {}
+        no_default_collection = False
+        default_collection_short = slugify(f"{product_name_for_packages}-{repo_name}-rpms")
+
+        for pkg in filtered_packages:
+            if pkg.module_name:
+                collection_short = f"{default_collection_short}__{pkg.module_name}"
+                if collection_short not in collections:
+                    collections[collection_short] = {
+                        "packages": [],
+                        "module_context": pkg.module_context,
+                        "module_name": pkg.module_name,
+                        "module_stream": pkg.module_stream,
+                        "module_version": pkg.module_version,
+                    }
+                    no_default_collection = True
+                collections[collection_short]["packages"].append(pkg)
+            else:
+                if no_default_collection:
+                    continue
+                if default_collection_short not in collections:
+                    collections[default_collection_short] = {
+                        "packages": [],
+                    }
+                collections[default_collection_short]["packages"].append(pkg)
+
+        if no_default_collection and default_collection_short in collections:
+            del collections[default_collection_short]
+
+        collections_added = 0
+
+        for collection_short, info in collections.items():
+            collection = ET.Element("collection")
+            collection.set("short", collection_short)
+
+            ET.SubElement(collection, "name").text = collection_short
+
+            if "module_name" in info:
+                module_element = ET.SubElement(collection, "module")
+                module_element.set("name", info["module_name"])
+                module_element.set("stream", info["module_stream"])
+                module_element.set("version", info["module_version"])
+                module_element.set("context", info["module_context"])
+                module_element.set("arch", adv_arch)
+
+            added_pkg_count = 0
+            for pkg in info["packages"]:
+                if pkg.nevra.endswith(".src.rpm"):
+                    continue
+
+                name = pkg.package_name
+                epoch = "0"
+                if NEVRA_RE.match(pkg.nevra):
+                    nevra = NEVRA_RE.search(pkg.nevra)
+                    name = nevra.group(1)
+                    epoch = nevra.group(2)
+                    version = nevra.group(3)
+                    release = nevra.group(4)
+                    arch = nevra.group(5)
+                elif NVRA_RE.match(pkg.nevra):
+                    nvra = NVRA_RE.search(pkg.nevra)
+                    name = nvra.group(1)
+                    version = nvra.group(2)
+                    release = nvra.group(3)
+                    arch = nvra.group(4)
+                else:
+                    continue
+
+                p_name = get_source_package_name(pkg)
+
+                if p_name not in pkg_src_rpm:
+                    continue
+                if arch != product_arch and arch != "noarch":
+                    if product_arch != "x86_64":
+                        continue
+                    if product_arch == "x86_64" and arch != "i686":
+                        continue
+
+                skip = False
+                for suffix in suffixes_to_skip:
+                    if name.endswith(suffix):
+                        skip = True
+                        break
+                if skip:
+                    continue
+
+                package = ET.SubElement(collection, "package")
+                package.set("name", name)
+                package.set("arch", arch)
+                package.set("epoch", epoch)
+                package.set("version", version)
+                package.set("release", release)
+                package.set("src", pkg_src_rpm[p_name])
+
+                ET.SubElement(package,
+                              "filename").text = EPOCH_RE.sub("", pkg.nevra)
+
+                ET.SubElement(
+                    package, "sum", type=pkg.checksum_type
+                ).text = pkg.checksum
+
+                added_pkg_count += 1
+
+            if added_pkg_count > 0:
+                packages_element.append(collection)
+                collections_added += 1
+
+        if collections_added == 0:
+            tree.remove(update)
+
+    ET.indent(tree)
+    xml_str = ET.tostring(
+        tree,
+        encoding="unicode",
+        method="xml",
+        short_empty_elements=True,
+    )
+
+    return xml_str
 
 
 @router.get("/{product_name}/{repo}/updateinfo.xml")
@@ -44,280 +367,112 @@ async def get_updateinfo(
     managing_editor = await get_setting(MANAGING_EDITOR)
     company_name = await get_setting(COMPANY_NAME)
 
-    advisories = {}
-    for affected_product in affected_products:
-        advisory = affected_product.advisory
-        if advisory.name not in advisories:
-            advisories[advisory.name] = {
-                "advisory":
-                    advisory,
-                "arch":
-                    affected_product.arch,
-                "major_version":
-                    affected_product.major_version,
-                "minor_version":
-                    affected_product.minor_version,
-                "supported_product_name":
-                    affected_product.supported_product.name,
-            }
+    product_arch = affected_products[0].arch
 
-    tree = ET.Element("updates")
-    for _, adv in advisories.items():
-        advisory = adv["advisory"]
-        product_arch = adv["arch"]
-        major_version = adv["major_version"]
-        minor_version = adv["minor_version"]
-        supported_product_name = adv["supported_product_name"]
+    xml_str = generate_updateinfo_xml(
+        affected_products=affected_products,
+        repo_name=repo,
+        product_arch=product_arch,
+        ui_url=ui_url,
+        managing_editor=managing_editor,
+        company_name=company_name,
+        product_name_for_packages=product_name,
+    )
 
-        update = ET.SubElement(tree, "update")
+    return Response(content=xml_str, media_type="application/xml")
 
-        # Set update attributes
-        update.set("from", managing_editor)
-        update.set("status", "final")
 
-        if advisory.kind == "Security":
-            update.set("type", "security")
-        elif advisory.kind == "Bug Fix":
-            update.set("type", "bugfix")
-        elif advisory.kind == "Enhancement":
-            update.set("type", "enhancement")
+@router.get("/{product}/{major_version}/{repo}/updateinfo.xml")
+async def get_updateinfo_v2(
+    product: str,
+    major_version: int,
+    repo: str,
+    arch: str,
+    minor_version: Optional[int] = None,
+):
+    """
+    Get updateinfo.xml for a product major version and repository.
 
-        update.set("version", "2")
+    This endpoint aggregates all advisories for the specified major version,
+    including all minor versions, unless minor_version is specified.
 
-        # Add id
-        ET.SubElement(update, "id").text = advisory.name
+    Architecture filtering is REQUIRED because:
+    - Each advisory contains packages for multiple architectures
+    - Repository structure is architecture-specific
+    - DNF/YUM expects arch-specific updateinfo.xml files
 
-        # Add title
-        ET.SubElement(update, "title").text = advisory.synopsis
+    Args:
+        product: Product slug (e.g., 'rocky-linux', 'rocky-linux-sig-cloud')
+        major_version: Major version number (e.g., 8, 9, 10)
+        repo: Repository name (e.g., 'BaseOS', 'AppStream')
+        arch: Architecture (REQUIRED: 'x86_64', 'aarch64', 'ppc64le', 's390x')
+        minor_version: Optional minor version filter (e.g., 6 for 8.6)
 
-        # Add time
-        time_format = "%Y-%m-%d %H:%M:%S"
-        issued = ET.SubElement(update, "issued")
-        issued.set("date", advisory.published_at.strftime(time_format))
-        updated = ET.SubElement(update, "updated")
-        updated.set("date", advisory.updated_at.strftime(time_format))
+    Returns:
+        updateinfo.xml file
 
-        # Add rights
-        now = datetime.datetime.utcnow()
-        ET.SubElement(
-            update, "rights"
-        ).text = f"Copyright {now.year} {company_name}"
+    Raises:
+        400: Invalid architecture or missing required parameter
+        404: No advisories found or invalid product
+    """
+    product_name = resolve_product_slug(product)
+    if not product_name:
+        raise RenderErrorTemplateException(
+            f"Unknown product: {product}. Valid: {', '.join(PRODUCT_SLUG_MAP.keys())}",
+            404
+        )
 
-        # Add release name
-        release_name = f"{supported_product_name} {major_version}"
-        if minor_version:
-            release_name += f".{minor_version}"
-        ET.SubElement(update, "release").text = release_name
+    try:
+        supported_product = await SupportedProduct.get(name=product_name)
+    except DoesNotExist:
+        raise RenderErrorTemplateException(f"Product not found: {product_name}", 404)
 
-        # Add pushcount
-        ET.SubElement(update, "pushcount").text = "1"
+    valid_arches = ["x86_64", "aarch64", "ppc64le", "s390x"]
+    if arch not in valid_arches:
+        raise RenderErrorTemplateException(
+            f"Invalid architecture: {arch}. Must be one of {', '.join(valid_arches)}",
+            400
+        )
 
-        # Add severity
-        ET.SubElement(update, "severity").text = advisory.severity
+    filters = {
+        "supported_product_id": supported_product.id,
+        "major_version": major_version,
+        "arch": arch,
+        "advisory__packages__repo_name": repo,
+        "advisory__packages__supported_product_id": supported_product.id,
+    }
 
-        # Add summary
-        ET.SubElement(update, "summary").text = advisory.topic
+    if minor_version is not None:
+        filters["minor_version"] = minor_version
 
-        # Add description
-        ET.SubElement(update, "description").text = advisory.description
+    affected_products = await AdvisoryAffectedProduct.filter(
+        **filters
+    ).prefetch_related(
+        "advisory",
+        "advisory__cves",
+        "advisory__fixes",
+        "advisory__packages",
+        "supported_product",
+    ).all()
 
-        # Add solution
-        ET.SubElement(update, "solution").text = ""
+    if not affected_products:
+        raise RenderErrorTemplateException(
+            f"No advisories found for {product_name} {major_version} {repo} {arch}",
+            404
+        )
 
-        # Add references
-        references = ET.SubElement(update, "references")
-        for cve in advisory.cves:
-            reference = ET.SubElement(references, "reference")
-            reference.set(
-                "href",
-                f"https://cve.mitre.org/cgi-bin/cvename.cgi?name={cve.cve}",
-            )
-            reference.set("id", cve.cve)
-            reference.set("type", "cve")
-            reference.set("title", cve.cve)
+    ui_url = await get_setting(UI_URL)
+    managing_editor = await get_setting(MANAGING_EDITOR)
+    company_name = await get_setting(COMPANY_NAME)
 
-        for fix in advisory.fixes:
-            reference = ET.SubElement(references, "reference")
-            reference.set("href", fix.source)
-            reference.set("id", fix.ticket_id)
-            reference.set("type", "bugzilla")
-            reference.set("title", fix.description)
-
-        # Add UI self reference
-        reference = ET.SubElement(references, "reference")
-        reference.set("href", f"{ui_url}/{advisory.name}")
-        reference.set("id", advisory.name)
-        reference.set("type", "self")
-        reference.set("title", advisory.name)
-
-        # Add packages
-        packages = ET.SubElement(update, "pkglist")
-
-        suffixes_to_skip = [
-            "-debuginfo",
-            "-debugsource",
-            "-debuginfo-common",
-            "-debugsource-common",
-        ]
-
-        pkg_name_map = {}
-        for pkg in advisory.packages:
-            name = pkg.package_name
-            if pkg.module_name:
-                name = f"{pkg.module_name}:{pkg.package_name}:{pkg.module_stream}"
-            if name not in pkg_name_map:
-                pkg_name_map[name] = []
-
-            pkg_name_map[name].append(pkg)
-
-        pkg_src_rpm = {}
-        for top_pkg in advisory.packages:
-            name = top_pkg.package_name
-            if top_pkg.module_name:
-                name = f"{top_pkg.module_name}:{top_pkg.package_name}:{top_pkg.module_stream}"
-            if name not in pkg_src_rpm:
-                for pkg in pkg_name_map[name]:
-                    nvra_no_epoch = EPOCH_RE.sub("", pkg.nevra)
-                    nvra = NVRA_RE.search(nvra_no_epoch)
-                    if nvra:
-                        nvr_name = nvra.group(1)
-                        nvr_arch = nvra.group(4)
-                        if pkg.package_name == nvr_name and nvr_arch == "src":
-                            src_rpm = nvra_no_epoch
-                            if not src_rpm.endswith(".rpm"):
-                                src_rpm += ".rpm"
-                            pkg_src_rpm[name] = src_rpm
-
-        # Collection list, may be more than one if module RPMs are involved
-        collections = {}
-        no_default_collection = False
-        default_collection_short = slugify(f"{product_name}-{repo}-rpms")
-
-        # Check if this is an actual module advisory, if so we need to split the
-        # collections, and module RPMs need to go into their own collection based on
-        # module name, while non-module RPMs go into the main collection (if any)
-        for pkg in advisory.packages:
-            if pkg.product_name != product_name:
-                continue
-            if pkg.repo_name != repo:
-                continue
-            if pkg.module_name:
-                collection_short = f"{default_collection_short}__{pkg.module_name}"
-                if collection_short not in collections:
-                    collections[collection_short] = {
-                        "packages": [],
-                        "module_context": pkg.module_context,
-                        "module_name": pkg.module_name,
-                        "module_stream": pkg.module_stream,
-                        "module_version": pkg.module_version,
-                    }
-                    no_default_collection = True
-                collections[collection_short]["packages"].append(pkg)
-            else:
-                if no_default_collection:
-                    continue
-                if default_collection_short not in collections:
-                    collections[default_collection_short] = {
-                        "packages": [],
-                    }
-                collections[default_collection_short]["packages"].append(pkg)
-
-        if no_default_collection and default_collection_short in collections:
-            del collections[default_collection_short]
-
-        collections_added = 0
-
-        for collection_short, info in collections.items():
-            # Create collection
-            collection = ET.Element("collection")
-            collection.set("short", collection_short)
-
-            # Set short to name as well
-            ET.SubElement(collection, "name").text = collection_short
-
-            if "module_name" in info:
-                module_element = ET.SubElement(collection, "module")
-                module_element.set("name", info["module_name"])
-                module_element.set("stream", info["module_stream"])
-                module_element.set("version", info["module_version"])
-                module_element.set("context", info["module_context"])
-                module_element.set("arch", product_arch)
-
-            added_pkg_count = 0
-            for pkg in info["packages"]:
-                if pkg.nevra.endswith(".src.rpm"):
-                    continue
-
-                name = pkg.package_name
-                epoch = "0"
-                if NEVRA_RE.match(pkg.nevra):
-                    nevra = NEVRA_RE.search(pkg.nevra)
-                    name = nevra.group(1)
-                    epoch = nevra.group(2)
-                    version = nevra.group(3)
-                    release = nevra.group(4)
-                    arch = nevra.group(5)
-                elif NVRA_RE.match(pkg.nevra):
-                    nvra = NVRA_RE.search(pkg.nevra)
-                    name = nvra.group(1)
-                    version = nvra.group(2)
-                    release = nvra.group(3)
-                    arch = nvra.group(4)
-                else:
-                    continue
-
-                p_name = pkg.package_name
-                if pkg.module_name:
-                    p_name = f"{pkg.module_name}:{pkg.package_name}:{pkg.module_stream}"
-
-                if p_name not in pkg_src_rpm:
-                    continue
-                if arch != product_arch and arch != "noarch":
-                    if product_arch != "x86_64":
-                        continue
-                    if product_arch == "x86_64" and arch != "i686":
-                        continue
-
-                skip = False
-                for suffix in suffixes_to_skip:
-                    if name.endswith(suffix):
-                        skip = True
-                        break
-                if skip:
-                    continue
-
-                package = ET.SubElement(collection, "package")
-                package.set("name", name)
-                package.set("arch", arch)
-                package.set("epoch", epoch)
-                package.set("version", version)
-                package.set("release", release)
-                package.set("src", pkg_src_rpm[p_name])
-
-                # Add filename element
-                ET.SubElement(package,
-                              "filename").text = EPOCH_RE.sub("", pkg.nevra)
-
-                # Add checksum
-                ET.SubElement(
-                    package, "sum", type=pkg.checksum_type
-                ).text = pkg.checksum
-
-                added_pkg_count += 1
-
-            if added_pkg_count > 0:
-                packages.append(collection)
-                collections_added += 1
-
-        if collections_added == 0:
-            tree.remove(update)
-
-    ET.indent(tree)
-    xml_str = ET.tostring(
-        tree,
-        encoding="unicode",
-        method="xml",
-        short_empty_elements=True,
+    xml_str = generate_updateinfo_xml(
+        affected_products=affected_products,
+        repo_name=repo,
+        product_arch=arch,
+        ui_url=ui_url,
+        managing_editor=managing_editor,
+        company_name=company_name,
+        supported_product_id=supported_product.id,
     )
 
     return Response(content=xml_str, media_type="application/xml")

--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -8,6 +8,7 @@ from slugify import slugify
 from apollo.db import AdvisoryAffectedProduct, SupportedProduct
 from tortoise.exceptions import DoesNotExist
 from apollo.server.settings import COMPANY_NAME, MANAGING_EDITOR, UI_URL, get_setting
+from apollo.server.validation import Architecture
 
 from apollo.rpmworker.repomd import NEVRA_RE, NVRA_RE, EPOCH_RE
 
@@ -424,8 +425,11 @@ async def get_updateinfo_v2(
     except DoesNotExist:
         raise RenderErrorTemplateException(f"Product not found: {product_name}", 404)
 
-    valid_arches = ["x86_64", "aarch64", "ppc64le", "s390x"]
-    if arch not in valid_arches:
+    # Validate architecture using centralized validation
+    try:
+        Architecture(arch)
+    except ValueError:
+        valid_arches = [a.value for a in Architecture]
         raise RenderErrorTemplateException(
             f"Invalid architecture: {arch}. Must be one of {', '.join(valid_arches)}",
             400

--- a/apollo/server/services/database_service.py
+++ b/apollo/server/services/database_service.py
@@ -185,5 +185,5 @@ class DatabaseService:
             }
 
         except Exception as e:
-            logger.error(f"Failed to update last_indexed_at: {str(e)}")
-            raise RuntimeError(f"Failed to update timestamp: {str(e)}")
+            logger.error(f"Failed to update last_indexed_at: {e}")
+            raise RuntimeError(f"Failed to update timestamp: {e}") from e

--- a/apollo/server/services/workflow_service.py
+++ b/apollo/server/services/workflow_service.py
@@ -206,9 +206,9 @@ class WorkflowService:
         
         # Import here to avoid circular imports
         from apollo.db import SupportedProductsRhMirror
-        
+
         # Get available major versions from RH mirrors
-        rh_mirrors = await SupportedProductsRhMirror.all()
+        rh_mirrors = await SupportedProductsRhMirror.filter(active=True)
         available_versions = {int(mirror.match_major_version) for mirror in rh_mirrors}
         
         # Check if all requested major versions are available

--- a/apollo/server/templates/admin_supported_product.jinja
+++ b/apollo/server/templates/admin_supported_product.jinja
@@ -41,13 +41,13 @@
     <div class="bx--row">
       <div class="bx--col">
         <div class="apollo-section-header">
-          <h2 class="bx--type-productive-heading-04">Red Hat Mirrors ({{ product.rh_mirrors|length }})</h2>
+          <h2 class="bx--type-productive-heading-04">Red Hat Mirrors ({{ mirrors|length }})</h2>
           <a href="/admin/supported-products/{{ product.id }}/mirrors/new" class="bx--btn bx--btn--primary">
             Add New Mirror
           </a>
         </div>
 
-        {% if product.rh_mirrors %}
+        {% if mirrors %}
         <div style="margin-bottom: 1rem; margin-top: 2rem">
           <form id="bulkDeleteForm" method="post" action="/admin/supported-products/{{ product.id }}/bulk-delete-mirrors" class="apollo-bulk-form">
             <input type="hidden" name="mirror_ids" id="mirror_ids" value="">
@@ -60,7 +60,7 @@
         </div>
         {% endif %}
 
-        {% if product.rh_mirrors %}
+        {% if mirrors %}
         <div class="apollo-table-container">
         <table class="bx--data-table apollo-mirrors-table">
           <thead class="apollo-sticky-header">
@@ -81,6 +81,9 @@
                 <span class="bx--table-header-label">Architecture</span>
               </th>
               <th>
+                <span class="bx--table-header-label">Status</span>
+              </th>
+              <th>
                 <span class="bx--table-header-label">Repositories</span>
               </th>
               <th>
@@ -92,7 +95,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for mirror in product.rh_mirrors %}
+            {% for mirror in mirrors %}
             <tr>
               <td class="apollo-checkbox-cell">
                 <input type="checkbox"
@@ -113,6 +116,13 @@
                 {{ mirror.match_major_version }}{% if mirror.match_minor_version %}.{{ mirror.match_minor_version }}{% endif %}
               </td>
               <td>{{ mirror.match_arch }}</td>
+              <td>
+                {% if mirror.active %}
+                <span class="bx--tag bx--tag--green">Active</span>
+                {% else %}
+                <span class="bx--tag bx--tag--gray">Inactive</span>
+                {% endif %}
+              </td>
               <td>
                 <span class="bx--tag bx--tag--blue">
                   {{ mirror.stats.repomds }} repos

--- a/apollo/server/templates/admin_supported_product_mirror.jinja
+++ b/apollo/server/templates/admin_supported_product_mirror.jinja
@@ -123,6 +123,7 @@
               <fieldset class="bx--fieldset">
                 <legend class="bx--label">Status</legend>
                 <div class="bx--form-item bx--checkbox-wrapper">
+                  <input type="hidden" name="active" value="false">
                   <input id="active" name="active" type="checkbox" value="true" class="bx--checkbox"
                          {% if mirror.active %}checked{% endif %}>
                   <label for="active" class="bx--checkbox-label">

--- a/apollo/server/templates/admin_supported_product_mirror.jinja
+++ b/apollo/server/templates/admin_supported_product_mirror.jinja
@@ -123,7 +123,6 @@
               <fieldset class="bx--fieldset">
                 <legend class="bx--label">Status</legend>
                 <div class="bx--form-item bx--checkbox-wrapper">
-                  <input type="hidden" name="active" value="false">
                   <input id="active" name="active" type="checkbox" value="true" class="bx--checkbox"
                          {% if mirror.active %}checked{% endif %}>
                   <label for="active" class="bx--checkbox-label">

--- a/apollo/server/templates/admin_supported_product_mirror.jinja
+++ b/apollo/server/templates/admin_supported_product_mirror.jinja
@@ -119,6 +119,22 @@
               </select>
             </div>
 
+            <div class="bx--form-item">
+              <fieldset class="bx--fieldset">
+                <legend class="bx--label">Status</legend>
+                <div class="bx--form-item bx--checkbox-wrapper">
+                  <input id="active" name="active" type="checkbox" value="true" class="bx--checkbox"
+                         {% if mirror.active %}checked{% endif %}>
+                  <label for="active" class="bx--checkbox-label">
+                    <span class="bx--checkbox-label-text">Active</span>
+                  </label>
+                </div>
+                <div class="bx--form__helper-text">
+                  Only active mirrors are used for advisory processing. Deactivate to exclude from workflows without deleting.
+                </div>
+              </fieldset>
+            </div>
+
             <button type="submit" class="bx--btn bx--btn--primary">
               Update Mirror
             </button>

--- a/apollo/server/templates/admin_supported_product_mirror_new.jinja
+++ b/apollo/server/templates/admin_supported_product_mirror_new.jinja
@@ -108,6 +108,22 @@
             </div>
           </div>
 
+          <div class="bx--form-item">
+            <fieldset class="bx--fieldset">
+              <legend class="bx--label">Status</legend>
+              <div class="bx--form-item bx--checkbox-wrapper">
+                <input id="active" name="active" type="checkbox" value="true" class="bx--checkbox"
+                       {% if not form_data or form_data.active == 'true' %}checked{% endif %}>
+                <label for="active" class="bx--checkbox-label">
+                  <span class="bx--checkbox-label-text">Active</span>
+                </label>
+              </div>
+              <div class="bx--form__helper-text">
+                Only active mirrors are used for advisory processing. Deactivate to exclude from workflows without deleting.
+              </div>
+            </fieldset>
+          </div>
+
           <div class="apollo-form-actions-spaced">
             <button type="submit" class="bx--btn bx--btn--primary">
               Create Mirror

--- a/apollo/server/templates/admin_supported_product_mirror_new.jinja
+++ b/apollo/server/templates/admin_supported_product_mirror_new.jinja
@@ -112,7 +112,6 @@
             <fieldset class="bx--fieldset">
               <legend class="bx--label">Status</legend>
               <div class="bx--form-item bx--checkbox-wrapper">
-                <input type="hidden" name="active" value="false">
                 <input id="active" name="active" type="checkbox" value="true" class="bx--checkbox"
                        {% if not form_data or form_data.active == 'true' %}checked{% endif %}>
                 <label for="active" class="bx--checkbox-label">

--- a/apollo/server/templates/admin_supported_product_mirror_new.jinja
+++ b/apollo/server/templates/admin_supported_product_mirror_new.jinja
@@ -112,6 +112,7 @@
             <fieldset class="bx--fieldset">
               <legend class="bx--label">Status</legend>
               <div class="bx--form-item bx--checkbox-wrapper">
+                <input type="hidden" name="active" value="false">
                 <input id="active" name="active" type="checkbox" value="true" class="bx--checkbox"
                        {% if not form_data or form_data.active == 'true' %}checked{% endif %}>
                 <label for="active" class="bx--checkbox-label">

--- a/apollo/server/templates/admin_workflows.jinja
+++ b/apollo/server/templates/admin_workflows.jinja
@@ -71,9 +71,47 @@
                     <h2 class="bx--type-productive-heading-03">Poll RH CSAF Advisories Workflow</h2>
                     <p class="bx--type-body-long-01">Polls Red Hat for new CSAF (Common Security Advisory Framework) advisories.</p>
 
-                    <form action="/admin/workflows/poll-rhcsaf/trigger" method="post" class="bx--form">
+                    <form action="/admin/workflows/poll-rhcsaf/trigger" method="post" class="bx--form" style="margin-top: 1rem;">
                         <button type="submit" class="bx--btn bx--btn--secondary">
                             Trigger Poll RHCSAF Workflow
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Update Index Timestamp Section -->
+        <div class="bx--row apollo-mt-3">
+            <div class="bx--col">
+                <div class="bx--tile">
+                    <h2 class="bx--type-productive-heading-03">Update CSAF Index Timestamp</h2>
+                    <p class="bx--type-body-long-01">Set the last_indexed_at timestamp to control which advisories are processed by the Poll RHCSAF workflow.</p>
+
+                    {% if last_indexed_exists %}
+                    <p class="bx--type-body-short-01" style="margin-top: 1rem;">
+                        <strong>Current last_indexed_at:</strong> {{ last_indexed_at }}
+                    </p>
+                    {% else %}
+                    <p class="bx--type-body-short-01" style="margin-top: 1rem; color: #da1e28;">
+                        <strong>No timestamp set</strong> - workflow will process all advisories
+                    </p>
+                    {% endif %}
+
+                    <form id="timestamp-form" action="/admin/workflows/update-index-timestamp" method="post" class="bx--form" style="margin-top: 1rem;">
+                        <div class="bx--form-item">
+                            <label for="timestamp_date" class="bx--label">
+                                Select Date (UTC timezone):
+                            </label>
+                            <input type="date" id="timestamp_date" name="timestamp_date" required class="bx--text-input apollo-width-auto apollo-max-width-12-5">
+                            <input type="hidden" id="new_timestamp" name="new_timestamp">
+                            <div class="bx--form__helper-text">
+                                The workflow will process advisories with timestamps after this date.<br>
+                                Time will be set to 00:00:00 UTC.
+                            </div>
+                        </div>
+
+                        <button type="submit" class="bx--btn bx--btn--tertiary">
+                            Update Timestamp
                         </button>
                     </form>
                 </div>
@@ -114,7 +152,7 @@
                     </div>
                 </div>
 
-                <div id="preview-results" class="apollo-mt-2 apollo-mb-2 apollo-p-2" style="display: none; border: 1px solid #ddd; border-radius: 4px; background-color: #f8f9fa;">
+                <div id="preview-results" class="apollo-mt-2 apollo-mb-2 apollo-p-2" style="display: none; border: 1px solid #ddd; border-radius: 4px; background-color: #f8f9fa; color: #161616;">
                     <!-- Preview results will be populated here -->
                 </div>
 
@@ -170,9 +208,29 @@
 </div>
 
 
-{% if reset_allowed %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    // Timestamp form handling
+    const timestampForm = document.getElementById('timestamp-form');
+    const timestampDateInput = document.getElementById('timestamp_date');
+    const timestampHiddenInput = document.getElementById('new_timestamp');
+
+    if (timestampForm && timestampDateInput && timestampHiddenInput) {
+        timestampForm.addEventListener('submit', function(e) {
+            const dateValue = timestampDateInput.value;
+            if (!dateValue) {
+                alert('Please select a date');
+                e.preventDefault();
+                return;
+            }
+            // Convert YYYY-MM-DD to ISO 8601 format with UTC timezone
+            const isoTimestamp = dateValue + 'T00:00:00+00:00';
+            timestampHiddenInput.value = isoTimestamp;
+        });
+    }
+
+    {% if reset_allowed %}
+    // Database reset form handling
     const confirmCheckbox = document.getElementById('confirm');
     const resetBtn = document.getElementById('reset-btn');
     const previewBtn = document.getElementById('preview-btn');
@@ -241,7 +299,7 @@ document.addEventListener('DOMContentLoaded', function() {
             previewResults.style.display = 'none';
         });
     }
+    {% endif %}
 });
 </script>
-{% endif %}
 {% endblock %}

--- a/apollo/server/validation.py
+++ b/apollo/server/validation.py
@@ -60,8 +60,8 @@ class ValidationPatterns:
     # URL validation - must start with http:// or https://
     URL_PATTERN = re.compile(r"^https?://.+")
 
-    # Name patterns - alphanumeric with common special characters and spaces
-    NAME_PATTERN = re.compile(r"^[a-zA-Z0-9._\s-]+$")
+    # Name patterns - alphanumeric with common special characters, spaces, and parentheses
+    NAME_PATTERN = re.compile(r"^[a-zA-Z0-9._\s()\-]+$")
 
     # Architecture validation
     ARCH_PATTERN = re.compile(r"^(x86_64|aarch64|i386|i686|ppc64|ppc64le|s390x|riscv64|noarch)$")
@@ -107,7 +107,7 @@ class FieldValidator:
 
         if not ValidationPatterns.NAME_PATTERN.match(trimmed_name):
             raise ValidationError(
-                f"{field_name.title()} can only contain letters, numbers, spaces, dots, hyphens, and underscores",
+                f"{field_name.title()} can only contain letters, numbers, spaces, dots, hyphens, underscores, and parentheses",
                 ValidationErrorType.INVALID_FORMAT,
                 field_name,
             )

--- a/apollo/server/validation.py
+++ b/apollo/server/validation.py
@@ -391,6 +391,13 @@ class ConfigValidator:
                     f"Config {config_index}: Mirror match_minor_version must be a non-negative integer"
                 )
 
+        # Validate active field if present
+        if "active" in mirror and mirror["active"] is not None:
+            if not isinstance(mirror["active"], bool):
+                errors.append(
+                    f"Config {config_index}: Mirror active must be a boolean value"
+                )
+
         return errors
 
     @staticmethod
@@ -524,6 +531,9 @@ class FormValidator:
         for field in ["match_variant", "match_major_version", "match_minor_version"]:
             if field in form_data:
                 validated_data[field] = form_data[field]
+
+        # Handle active checkbox (form data comes as string "true"/"false" or may be missing)
+        validated_data["active"] = form_data.get("active", "true") == "true"
 
         return validated_data, errors
 

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -88,3 +88,12 @@ py_test(
         "//common:common_lib",
     ],
 )
+
+py_test(
+    name = "test_rh_matcher_activities",
+    srcs = ["test_rh_matcher_activities.py"],
+    deps = [
+        "//apollo/rpmworker:rpmworker_lib",
+        "//apollo/rpm_helpers:rpm_helpers_lib",
+    ],
+)

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -69,3 +69,13 @@ py_test(
         "//apollo/server:server_lib",
     ],
 )
+
+py_test(
+    name = "test_database_service",
+    srcs = ["test_database_service.py"],
+    deps = [
+        "//apollo/server:server_lib",
+        "//apollo/db:db_lib",
+        "//common:common_lib",
+    ],
+)

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -45,6 +45,15 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_api_updateinfo",
+    srcs = ["test_api_updateinfo.py"],
+    deps = [
+        "//apollo/server:server_lib",
+        "//apollo/db:db_lib",
+    ],
+)
+
 
 py_test(
     name = "test_validation",

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -61,3 +61,11 @@ py_test(
         "//apollo/server:server_lib",
     ],
 )
+
+py_test(
+    name = "test_api_osv",
+    srcs = ["test_api_osv.py"],
+    deps = [
+        "//apollo/server:server_lib",
+    ],
+)

--- a/apollo/tests/test_admin_routes_supported_products.py
+++ b/apollo/tests/test_admin_routes_supported_products.py
@@ -446,31 +446,26 @@ class TestActiveFieldCheckboxParsing(unittest.TestCase):
 
     def test_checkbox_checked_returns_true(self):
         """Test that checked checkbox results in active_value='true'."""
-        # Simulate form data when checkbox is checked
         from unittest.mock import Mock
         form_data = Mock()
         form_data.getlist.return_value = ["true"]
 
-        # Apply the parsing logic from admin_supported_products.py
         active_value = "true" if "true" in form_data.getlist("active") else "false"
 
         self.assertEqual(active_value, "true")
 
     def test_checkbox_unchecked_returns_false(self):
         """Test that unchecked checkbox results in active_value='false'."""
-        # Simulate form data when checkbox is unchecked (empty list)
         from unittest.mock import Mock
         form_data = Mock()
         form_data.getlist.return_value = []
 
-        # Apply the parsing logic from admin_supported_products.py
         active_value = "true" if "true" in form_data.getlist("active") else "false"
 
         self.assertEqual(active_value, "false")
 
     def test_checkbox_missing_field_defaults_to_false(self):
         """Test that missing active field defaults to false."""
-        # Simulate form data without active field at all
         from unittest.mock import Mock
         form_data = Mock()
         form_data.getlist.return_value = []
@@ -481,7 +476,6 @@ class TestActiveFieldCheckboxParsing(unittest.TestCase):
 
     def test_checkbox_boolean_conversion(self):
         """Test that string active_value converts correctly to boolean."""
-        # Test conversion to boolean for database storage
         active_value_true = "true"
         active_value_false = "false"
 
@@ -490,14 +484,12 @@ class TestActiveFieldCheckboxParsing(unittest.TestCase):
 
     def test_checkbox_with_unexpected_value(self):
         """Test that unexpected values default to false."""
-        # Edge case: unexpected value
         from unittest.mock import Mock
         form_data = Mock()
         form_data.getlist.return_value = ["yes", "1", "on"]
 
         active_value = "true" if "true" in form_data.getlist("active") else "false"
 
-        # Should default to false since "true" is not in the list
         self.assertEqual(active_value, "false")
 
 

--- a/apollo/tests/test_admin_routes_supported_products.py
+++ b/apollo/tests/test_admin_routes_supported_products.py
@@ -168,8 +168,8 @@ class TestJSONSerialization(unittest.TestCase):
         """Test JSON serializer with integer Decimal."""
         decimal_val = Decimal("42")
         result = _json_serializer(decimal_val)
-        self.assertEqual(result, 42.0)
-        self.assertIsInstance(result, float)
+        self.assertEqual(result, 42)
+        self.assertIsInstance(result, int)
 
     def test_json_serializer_unsupported_type(self):
         """Test JSON serializer with unsupported type."""
@@ -211,10 +211,11 @@ class TestJSONSerialization(unittest.TestCase):
 
         result = _format_export_data(data)
 
-        # Should be valid JSON with Decimals converted to floats
+        # Should be valid JSON with Decimals converted appropriately
+        # (floats for decimals, ints for whole numbers)
         parsed = json.loads(result)
         self.assertEqual(parsed[0]["price"], 19.99)
-        self.assertEqual(parsed[1]["price"], 99.0)
+        self.assertEqual(parsed[1]["price"], 99)
 
     def test_format_export_data_empty(self):
         """Test formatting empty export data."""

--- a/apollo/tests/test_admin_routes_supported_products.py
+++ b/apollo/tests/test_admin_routes_supported_products.py
@@ -211,8 +211,6 @@ class TestJSONSerialization(unittest.TestCase):
 
         result = _format_export_data(data)
 
-        # Should be valid JSON with Decimals converted appropriately
-        # (floats for decimals, ints for whole numbers)
         parsed = json.loads(result)
         self.assertEqual(parsed[0]["price"], 19.99)
         self.assertEqual(parsed[1]["price"], 99)

--- a/apollo/tests/test_api_osv.py
+++ b/apollo/tests/test_api_osv.py
@@ -1,0 +1,248 @@
+"""
+Tests for OSV API CVE filtering functionality
+"""
+
+import unittest
+import datetime
+from unittest.mock import Mock
+
+from apollo.server.routes.api_osv import to_osv_advisory
+
+
+class MockSupportedProduct:
+    """Mock SupportedProduct model"""
+
+    def __init__(self, variant="Rocky Linux", vendor="Rocky Enterprise Software Foundation"):
+        self.variant = variant
+        self.vendor = vendor
+
+
+class MockSupportedProductsRhMirror:
+    """Mock SupportedProductsRhMirror model"""
+
+    def __init__(self, match_major_version=9):
+        self.match_major_version = match_major_version
+
+
+class MockPackage:
+    """Mock Package model"""
+
+    def __init__(
+        self,
+        nevra,
+        product_name="Rocky Linux 9",
+        repo_name="BaseOS",
+        supported_product=None,
+        supported_products_rh_mirror=None,
+    ):
+        self.nevra = nevra
+        self.product_name = product_name
+        self.repo_name = repo_name
+        self.supported_product = supported_product or MockSupportedProduct()
+        self.supported_products_rh_mirror = supported_products_rh_mirror
+
+
+class MockCVE:
+    """Mock CVE model"""
+
+    def __init__(
+        self,
+        cve="CVE-2024-1234",
+        cvss3_base_score="7.5",
+        cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+    ):
+        self.cve = cve
+        self.cvss3_base_score = cvss3_base_score
+        self.cvss3_scoring_vector = cvss3_scoring_vector
+
+
+class MockFix:
+    """Mock Fix model"""
+
+    def __init__(self, source="https://bugzilla.redhat.com/show_bug.cgi?id=1234567"):
+        self.source = source
+
+
+class MockAdvisory:
+    """Mock Advisory model"""
+
+    def __init__(
+        self,
+        name="RLSA-2024:1234",
+        synopsis="Important: test security update",
+        description="A security update for test package",
+        published_at=None,
+        updated_at=None,
+        packages=None,
+        cves=None,
+        fixes=None,
+        red_hat_advisory=None,
+    ):
+        self.name = name
+        self.synopsis = synopsis
+        self.description = description
+        self.published_at = published_at or datetime.datetime.now(
+            datetime.timezone.utc
+        )
+        self.updated_at = updated_at or datetime.datetime.now(datetime.timezone.utc)
+        self.packages = packages or []
+        self.cves = cves or []
+        self.fixes = fixes or []
+        self.red_hat_advisory = red_hat_advisory
+
+
+class TestOSVCVEFiltering(unittest.TestCase):
+    """Test CVE filtering logic in OSV API"""
+
+    def test_advisory_with_cve_has_upstream_references(self):
+        """Test that advisories with CVEs have upstream references populated"""
+        packages = [
+            MockPackage(
+                nevra="pcs-0:0.11.8-2.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE(cve="CVE-2024-1234")]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.upstream)
+        self.assertEqual(len(result.upstream), 1)
+        self.assertIn("CVE-2024-1234", result.upstream)
+
+    def test_advisory_with_multiple_cves(self):
+        """Test that advisories with multiple CVEs include all in upstream"""
+        packages = [
+            MockPackage(
+                nevra="openssl-1:3.0.7-28.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [
+            MockCVE(cve="CVE-2024-1111"),
+            MockCVE(cve="CVE-2024-2222"),
+            MockCVE(cve="CVE-2024-3333"),
+        ]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.upstream)
+        self.assertEqual(len(result.upstream), 3)
+        self.assertIn("CVE-2024-1111", result.upstream)
+        self.assertIn("CVE-2024-2222", result.upstream)
+        self.assertIn("CVE-2024-3333", result.upstream)
+
+    def test_advisory_without_cves_has_empty_upstream(self):
+        """Test that advisories without CVEs have empty upstream list"""
+        packages = [
+            MockPackage(
+                nevra="kernel-0:5.14.0-427.el9.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+
+        advisory = MockAdvisory(packages=packages, cves=[])
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.upstream)
+        self.assertEqual(len(result.upstream), 0)
+
+    def test_source_packages_only(self):
+        """Test that only source packages are processed, not binary packages"""
+        packages = [
+            MockPackage(
+                nevra="httpd-0:2.4.57-8.el9.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+            MockPackage(
+                nevra="httpd-0:2.4.57-8.el9.x86_64",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+            MockPackage(
+                nevra="httpd-0:2.4.57-8.el9.aarch64",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE()]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        # Should only have 1 affected package (the source package)
+        self.assertEqual(len(result.affected), 1)
+        self.assertEqual(result.affected[0].package.name, "httpd")
+
+    def test_severity_from_highest_cvss(self):
+        """Test that severity uses the highest CVSS score from multiple CVEs"""
+        packages = [
+            MockPackage(
+                nevra="vim-2:9.0.1592-1.el9.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [
+            MockCVE(
+                cve="CVE-2024-1111",
+                cvss3_base_score="5.5",
+                cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            ),
+            MockCVE(
+                cve="CVE-2024-2222",
+                cvss3_base_score="9.8",
+                cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            ),
+            MockCVE(
+                cve="CVE-2024-3333",
+                cvss3_base_score="7.5",
+                cvss3_scoring_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            ),
+        ]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertIsNotNone(result.severity)
+        self.assertEqual(len(result.severity), 1)
+        self.assertEqual(result.severity[0].type, "CVSS_V3")
+        self.assertEqual(
+            result.severity[0].score, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        )
+
+    def test_ecosystem_format(self):
+        """Test that ecosystem field is formatted correctly"""
+        packages = [
+            MockPackage(
+                nevra="bash-0:5.1.8-9.el9.src",
+                product_name="Rocky Linux 9",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE()]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        self.assertEqual(len(result.affected), 1)
+        self.assertEqual(result.affected[0].package.ecosystem, "Rocky Linux:9")
+
+    def test_version_format_with_epoch(self):
+        """Test that fixed version includes epoch in epoch:version-release format"""
+        packages = [
+            MockPackage(
+                nevra="systemd-0:252-38.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        cves = [MockCVE()]
+
+        advisory = MockAdvisory(packages=packages, cves=cves)
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        fixed_version = result.affected[0].ranges[0].events[1].fixed
+        self.assertEqual(fixed_version, "0:252-38.el9_5")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/apollo/tests/test_api_updateinfo.py
+++ b/apollo/tests/test_api_updateinfo.py
@@ -63,20 +63,20 @@ class TestGetSourcePackageName(unittest.TestCase):
         result = get_source_package_name(pkg)
         self.assertEqual(result, "python27:python-markupsafe:el8")
 
-    def test_module_package_with_prefix(self):
-        """Test module package with module. prefix (bug case)"""
+    def test_module_package_cleaned_by_orm(self):
+        """Test module package (ORM strips module. prefix automatically)"""
         pkg = Mock()
-        pkg.package_name = "module.python-markupsafe"
+        pkg.package_name = "python-markupsafe"  # ORM already cleaned
         pkg.module_name = "python27"
         pkg.module_stream = "el8"
 
         result = get_source_package_name(pkg)
         self.assertEqual(result, "python27:python-markupsafe:el8")
 
-    def test_regular_package_with_prefix(self):
-        """Test regular package with module. prefix gets stripped"""
+    def test_regular_package_cleaned_by_orm(self):
+        """Test regular package (ORM strips module. prefix automatically)"""
         pkg = Mock()
-        pkg.package_name = "module.delve"
+        pkg.package_name = "delve"  # ORM already cleaned
         pkg.module_name = None
 
         result = get_source_package_name(pkg)
@@ -127,16 +127,16 @@ class TestBuildSourceRpmMapping(unittest.TestCase):
 
         self.assertEqual(result, {"python-markupsafe": "python-markupsafe-0.23-19.el8.src.rpm"})
 
-    def test_module_package_with_prefix(self):
-        """Test module package with module. prefix"""
+    def test_module_package_cleaned_by_orm(self):
+        """Test module package (ORM strips module. prefix automatically)"""
         src_pkg = Mock()
-        src_pkg.package_name = "module.python-markupsafe"
+        src_pkg.package_name = "python-markupsafe"  # ORM already cleaned
         src_pkg.module_name = "python27"
         src_pkg.module_stream = "el8"
         src_pkg.nevra = "python-markupsafe-0.23-19.module+el8.5.0+706+735ec4b3.src.rpm"
 
         bin_pkg = Mock()
-        bin_pkg.package_name = "python-markupsafe"
+        bin_pkg.package_name = "python-markupsafe"  # ORM already cleaned
         bin_pkg.module_name = "python27"
         bin_pkg.module_stream = "el8"
         bin_pkg.nevra = "python2-markupsafe-0.23-19.module+el8.5.0+706+735ec4b3.x86_64.rpm"

--- a/apollo/tests/test_api_updateinfo.py
+++ b/apollo/tests/test_api_updateinfo.py
@@ -1,0 +1,181 @@
+"""
+Tests for updateinfo API endpoints and helper functions
+"""
+
+import unittest
+import sys
+import os
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from apollo.server.routes.api_updateinfo import (
+    resolve_product_slug,
+    get_source_package_name,
+    build_source_rpm_mapping,
+    PRODUCT_SLUG_MAP,
+)
+
+
+class TestProductSlugResolution(unittest.TestCase):
+    """Test product slug resolution"""
+
+    def test_valid_slug_rocky_linux(self):
+        """Test resolving rocky-linux slug"""
+        result = resolve_product_slug("rocky-linux")
+        self.assertEqual(result, "Rocky Linux")
+
+    def test_valid_slug_case_insensitive(self):
+        """Test slug resolution is case-insensitive"""
+        result = resolve_product_slug("ROCKY-LINUX")
+        self.assertEqual(result, "Rocky Linux")
+
+    def test_invalid_slug(self):
+        """Test invalid slug returns None"""
+        result = resolve_product_slug("invalid-product")
+        self.assertIsNone(result)
+
+    def test_sig_cloud_slug(self):
+        """Test resolving sig-cloud slug"""
+        result = resolve_product_slug("rocky-linux-sig-cloud")
+        self.assertEqual(result, "Rocky Linux SIG Cloud")
+
+
+class TestGetSourcePackageName(unittest.TestCase):
+    """Test get_source_package_name helper"""
+
+    def test_regular_package(self):
+        """Test regular package without module"""
+        pkg = Mock()
+        pkg.package_name = "kernel"
+        pkg.module_name = None
+
+        result = get_source_package_name(pkg)
+        self.assertEqual(result, "kernel")
+
+    def test_module_package_without_prefix(self):
+        """Test module package without module. prefix"""
+        pkg = Mock()
+        pkg.package_name = "python-markupsafe"
+        pkg.module_name = "python27"
+        pkg.module_stream = "el8"
+
+        result = get_source_package_name(pkg)
+        self.assertEqual(result, "python27:python-markupsafe:el8")
+
+    def test_module_package_with_prefix(self):
+        """Test module package with module. prefix (bug case)"""
+        pkg = Mock()
+        pkg.package_name = "module.python-markupsafe"
+        pkg.module_name = "python27"
+        pkg.module_stream = "el8"
+
+        result = get_source_package_name(pkg)
+        self.assertEqual(result, "python27:python-markupsafe:el8")
+
+    def test_regular_package_with_prefix(self):
+        """Test regular package with module. prefix gets stripped"""
+        pkg = Mock()
+        pkg.package_name = "module.delve"
+        pkg.module_name = None
+
+        result = get_source_package_name(pkg)
+        self.assertEqual(result, "delve")
+
+
+class TestBuildSourceRpmMapping(unittest.TestCase):
+    """Test build_source_rpm_mapping helper"""
+
+    def test_simple_source_rpm_mapping(self):
+        """Test mapping for simple package"""
+        src_pkg = Mock()
+        src_pkg.package_name = "kernel"
+        src_pkg.module_name = None
+        src_pkg.nevra = "kernel-4.18.0-425.el8.src.rpm"
+
+        bin_pkg = Mock()
+        bin_pkg.package_name = "kernel"
+        bin_pkg.module_name = None
+        bin_pkg.nevra = "kernel-4.18.0-425.el8.x86_64.rpm"
+
+        packages = [src_pkg, bin_pkg]
+
+        result = build_source_rpm_mapping(packages)
+
+        self.assertEqual(result, {"kernel": "kernel-4.18.0-425.el8.src.rpm"})
+
+    def test_multi_binary_source_rpm_mapping(self):
+        """Test mapping when multiple binaries share one source"""
+        src_pkg = Mock()
+        src_pkg.package_name = "python-markupsafe"
+        src_pkg.module_name = None
+        src_pkg.nevra = "python-markupsafe-0.23-19.el8.src.rpm"
+
+        bin_pkg1 = Mock()
+        bin_pkg1.package_name = "python-markupsafe"
+        bin_pkg1.module_name = None
+        bin_pkg1.nevra = "python2-markupsafe-0.23-19.el8.x86_64.rpm"
+
+        bin_pkg2 = Mock()
+        bin_pkg2.package_name = "python-markupsafe"
+        bin_pkg2.module_name = None
+        bin_pkg2.nevra = "python3-markupsafe-0.23-19.el8.x86_64.rpm"
+
+        packages = [src_pkg, bin_pkg1, bin_pkg2]
+
+        result = build_source_rpm_mapping(packages)
+
+        self.assertEqual(result, {"python-markupsafe": "python-markupsafe-0.23-19.el8.src.rpm"})
+
+    def test_module_package_with_prefix(self):
+        """Test module package with module. prefix"""
+        src_pkg = Mock()
+        src_pkg.package_name = "module.python-markupsafe"
+        src_pkg.module_name = "python27"
+        src_pkg.module_stream = "el8"
+        src_pkg.nevra = "python-markupsafe-0.23-19.module+el8.5.0+706+735ec4b3.src.rpm"
+
+        bin_pkg = Mock()
+        bin_pkg.package_name = "python-markupsafe"
+        bin_pkg.module_name = "python27"
+        bin_pkg.module_stream = "el8"
+        bin_pkg.nevra = "python2-markupsafe-0.23-19.module+el8.5.0+706+735ec4b3.x86_64.rpm"
+
+        packages = [src_pkg, bin_pkg]
+
+        result = build_source_rpm_mapping(packages)
+
+        expected_key = "python27:python-markupsafe:el8"
+        self.assertIn(expected_key, result)
+        self.assertEqual(result[expected_key], "python-markupsafe-0.23-19.module+el8.5.0+706+735ec4b3.src.rpm")
+
+    def test_no_source_rpm(self):
+        """Test when no source RPM is present"""
+        bin_pkg = Mock()
+        bin_pkg.package_name = "kernel"
+        bin_pkg.module_name = None
+        bin_pkg.nevra = "kernel-4.18.0-425.el8.x86_64.rpm"
+
+        packages = [bin_pkg]
+
+        result = build_source_rpm_mapping(packages)
+
+        self.assertEqual(result, {})
+
+
+class TestProductSlugMapping(unittest.TestCase):
+    """Test product slug mapping configuration"""
+
+    def test_slug_map_contains_rocky_linux(self):
+        """Test slug map contains rocky-linux"""
+        self.assertIn("rocky-linux", PRODUCT_SLUG_MAP)
+        self.assertEqual(PRODUCT_SLUG_MAP["rocky-linux"], "Rocky Linux")
+
+    def test_slug_map_contains_sig_cloud(self):
+        """Test slug map contains sig-cloud"""
+        self.assertIn("rocky-linux-sig-cloud", PRODUCT_SLUG_MAP)
+        self.assertEqual(PRODUCT_SLUG_MAP["rocky-linux-sig-cloud"], "Rocky Linux SIG Cloud")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apollo/tests/test_database_service.py
+++ b/apollo/tests/test_database_service.py
@@ -1,0 +1,226 @@
+"""
+Tests for DatabaseService functionality
+Tests utility functions for database operations including timestamp management
+"""
+
+import unittest
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import Mock, AsyncMock, patch
+import os
+
+# Add the project root to the Python path
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from apollo.server.services.database_service import DatabaseService
+
+
+class TestEnvironmentDetection(unittest.TestCase):
+    """Test environment detection functionality."""
+
+    def test_is_production_when_env_is_production(self):
+        """Test production detection when ENV=production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            self.assertTrue(service.is_production_environment())
+
+    def test_is_not_production_when_env_is_development(self):
+        """Test production detection when ENV=development."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            self.assertFalse(service.is_production_environment())
+
+    def test_is_not_production_when_env_not_set(self):
+        """Test production detection when ENV is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            service = DatabaseService()
+            self.assertFalse(service.is_production_environment())
+
+    def test_is_not_production_with_staging_env(self):
+        """Test production detection with staging environment."""
+        with patch.dict(os.environ, {"ENV": "staging"}):
+            service = DatabaseService()
+            self.assertFalse(service.is_production_environment())
+
+    def test_get_environment_info_production(self):
+        """Test getting environment info for production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            result = asyncio.run(service.get_environment_info())
+
+            self.assertEqual(result["environment"], "production")
+            self.assertTrue(result["is_production"])
+            self.assertFalse(result["reset_allowed"])
+
+    def test_get_environment_info_development(self):
+        """Test getting environment info for development."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            result = asyncio.run(service.get_environment_info())
+
+            self.assertEqual(result["environment"], "development")
+            self.assertFalse(result["is_production"])
+            self.assertTrue(result["reset_allowed"])
+
+
+class TestLastIndexedAtOperations(unittest.TestCase):
+    """Test last_indexed_at timestamp operations."""
+
+    def test_get_last_indexed_at_when_exists(self):
+        """Test getting last_indexed_at when record exists."""
+        mock_index_state = Mock()
+        test_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_index_state.last_indexed_at = test_time
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state:
+            mock_state.first = AsyncMock(return_value=mock_index_state)
+
+            service = DatabaseService()
+            result = asyncio.run(service.get_last_indexed_at())
+
+            self.assertEqual(result["last_indexed_at"], test_time)
+            self.assertEqual(result["last_indexed_at_iso"], "2025-07-01T00:00:00+00:00")
+            self.assertTrue(result["exists"])
+
+    def test_get_last_indexed_at_when_not_exists(self):
+        """Test getting last_indexed_at when no record exists."""
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state:
+            mock_state.first = AsyncMock(return_value=None)
+
+            service = DatabaseService()
+            result = asyncio.run(service.get_last_indexed_at())
+
+            self.assertIsNone(result["last_indexed_at"])
+            self.assertIsNone(result["last_indexed_at_iso"])
+            self.assertFalse(result["exists"])
+
+    def test_get_last_indexed_at_when_timestamp_is_none(self):
+        """Test getting last_indexed_at when timestamp field is None."""
+        mock_index_state = Mock()
+        mock_index_state.last_indexed_at = None
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state:
+            mock_state.first = AsyncMock(return_value=mock_index_state)
+
+            service = DatabaseService()
+            result = asyncio.run(service.get_last_indexed_at())
+
+            self.assertIsNone(result["last_indexed_at"])
+            self.assertIsNone(result["last_indexed_at_iso"])
+            self.assertFalse(result["exists"])
+
+    def test_update_last_indexed_at_existing_record(self):
+        """Test updating last_indexed_at for existing record."""
+        old_time = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        new_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        mock_index_state = Mock()
+        mock_index_state.last_indexed_at = old_time
+        mock_index_state.save = AsyncMock()
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state, \
+             patch("apollo.server.services.database_service.Logger"):
+            mock_state.first = AsyncMock(return_value=mock_index_state)
+
+            service = DatabaseService()
+            result = asyncio.run(service.update_last_indexed_at(new_time, "admin@example.com"))
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["old_timestamp"], "2025-06-01T00:00:00+00:00")
+            self.assertEqual(result["new_timestamp"], "2025-07-01T00:00:00+00:00")
+            self.assertIn("Successfully updated", result["message"])
+
+            # Verify save was called
+            mock_index_state.save.assert_called_once()
+            # Verify timestamp was updated
+            self.assertEqual(mock_index_state.last_indexed_at, new_time)
+
+    def test_update_last_indexed_at_create_new_record(self):
+        """Test updating last_indexed_at when no record exists (creates new)."""
+        new_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state, \
+             patch("apollo.server.services.database_service.Logger"):
+            mock_state.first = AsyncMock(return_value=None)
+            mock_state.create = AsyncMock()
+
+            service = DatabaseService()
+            result = asyncio.run(service.update_last_indexed_at(new_time, "admin@example.com"))
+
+            self.assertTrue(result["success"])
+            self.assertIsNone(result["old_timestamp"])
+            self.assertEqual(result["new_timestamp"], "2025-07-01T00:00:00+00:00")
+            self.assertIn("Successfully updated", result["message"])
+
+            # Verify create was called with correct timestamp
+            mock_state.create.assert_called_once_with(last_indexed_at=new_time)
+
+    def test_update_last_indexed_at_handles_exception(self):
+        """Test that update_last_indexed_at handles database exceptions."""
+        new_time = datetime(2025, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        with patch("apollo.server.services.database_service.RedHatIndexState") as mock_state, \
+             patch("apollo.server.services.database_service.Logger"):
+            mock_state.first = AsyncMock(side_effect=Exception("Database error"))
+
+            service = DatabaseService()
+
+            with self.assertRaises(RuntimeError) as cm:
+                asyncio.run(service.update_last_indexed_at(new_time, "admin@example.com"))
+
+            self.assertIn("Failed to update timestamp", str(cm.exception))
+
+
+class TestPartialResetValidation(unittest.TestCase):
+    """Test partial reset validation logic."""
+
+    def test_preview_partial_reset_blocks_in_production(self):
+        """Test that preview_partial_reset raises error in production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            cutoff_date = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.preview_partial_reset(cutoff_date))
+
+            self.assertIn("production environment", str(cm.exception))
+
+    def test_preview_partial_reset_rejects_future_date(self):
+        """Test that preview_partial_reset rejects future dates."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            future_date = datetime(2099, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.preview_partial_reset(future_date))
+
+            self.assertIn("must be in the past", str(cm.exception))
+
+    def test_perform_partial_reset_blocks_in_production(self):
+        """Test that perform_partial_reset raises error in production."""
+        with patch.dict(os.environ, {"ENV": "production"}):
+            service = DatabaseService()
+            cutoff_date = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.perform_partial_reset(cutoff_date, "admin@example.com"))
+
+            self.assertIn("production environment", str(cm.exception))
+
+    def test_perform_partial_reset_rejects_future_date(self):
+        """Test that perform_partial_reset rejects future dates."""
+        with patch.dict(os.environ, {"ENV": "development"}):
+            service = DatabaseService()
+            future_date = datetime(2099, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+            with self.assertRaises(ValueError) as cm:
+                asyncio.run(service.perform_partial_reset(future_date, "admin@example.com"))
+
+            self.assertIn("must be in the past", str(cm.exception))
+
+
+if __name__ == "__main__":
+    # Run with verbose output
+    unittest.main(verbosity=2)

--- a/apollo/tests/test_rh_matcher_activities.py
+++ b/apollo/tests/test_rh_matcher_activities.py
@@ -1,0 +1,131 @@
+"""
+Tests for RH matcher activities package_name extraction logic
+"""
+
+import unittest
+import sys
+import os
+from unittest.mock import Mock, MagicMock, patch
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from apollo.rpmworker import repomd
+
+
+class TestPackageNameExtraction(unittest.TestCase):
+    """Test package_name extraction from source RPMs"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_advisory_nvra = "libarchive-3.3.3-5.el8.src.rpm"
+        self.test_binary_nvra = "libarchive-0:3.3.3-5.el8.x86_64.rpm"
+        self.test_debuginfo_nvra = "libarchive-debuginfo-0:3.3.3-5.el8.aarch64.rpm"
+
+    def test_nvra_regex_matches_source_rpm(self):
+        """Test NVRA_RE regex matches source RPM correctly"""
+        match = repomd.NVRA_RE.search(self.test_advisory_nvra)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "libarchive")
+
+    def test_nvra_regex_matches_binary_rpm(self):
+        """Test NVRA_RE regex matches binary RPM name"""
+        source_rpm_text = "libarchive-3.3.3-5.el8.src.rpm"
+        match = repomd.NVRA_RE.search(source_rpm_text)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "libarchive")
+
+    def test_nvra_regex_handles_module_packages(self):
+        """Test NVRA_RE regex extracts package name from module packages"""
+        module_source_rpm = "postgresql-12.5-1.module+el8.3.0+6656+95b1e5d5.src.rpm"
+        match = repomd.NVRA_RE.search(module_source_rpm)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "postgresql")
+
+    def test_nvra_regex_no_match_returns_none(self):
+        """Test NVRA_RE regex returns None for invalid format"""
+        invalid_nvra = "not-a-valid-package-name"
+        match = repomd.NVRA_RE.search(invalid_nvra)
+        self.assertIsNone(match)
+
+    def test_source_rpm_element_handling(self):
+        """Test handling of missing source_rpm XML element"""
+        xml_with_sourcerpm = """
+        <package xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+            <format>
+                <rpm:sourcerpm>libarchive-3.3.3-5.el8.src.rpm</rpm:sourcerpm>
+            </format>
+        </package>
+        """
+        xml_without_sourcerpm = """
+        <package xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+            <format>
+            </format>
+        </package>
+        """
+
+        root_with = ET.fromstring(xml_with_sourcerpm)
+        source_rpm_with = root_with.find("format").find("{http://linux.duke.edu/metadata/rpm}sourcerpm")
+        self.assertIsNotNone(source_rpm_with)
+
+        root_without = ET.fromstring(xml_without_sourcerpm)
+        source_rpm_without = root_without.find("format").find("{http://linux.duke.edu/metadata/rpm}sourcerpm")
+        self.assertIsNone(source_rpm_without)
+
+    def test_package_name_extraction_workflow(self):
+        """Test complete workflow of package_name extraction with various scenarios"""
+        test_cases = [
+            {
+                "name": "Valid source RPM",
+                "advisory_nvra": "libarchive-3.3.3-5.el8.src.rpm",
+                "is_source": True,
+                "source_rpm_text": None,
+                "expected": "libarchive"
+            },
+            {
+                "name": "Valid binary RPM with source",
+                "advisory_nvra": "libarchive-0:3.3.3-5.el8.x86_64",
+                "is_source": False,
+                "source_rpm_text": "libarchive-3.3.3-5.el8.src.rpm",
+                "expected": "libarchive"
+            },
+            {
+                "name": "Binary RPM with missing source",
+                "advisory_nvra": "libarchive-debuginfo-0:3.3.3-5.el8.aarch64",
+                "is_source": False,
+                "source_rpm_text": None,
+                "expected": None
+            },
+            {
+                "name": "Invalid source RPM format",
+                "advisory_nvra": "invalid-format",
+                "is_source": True,
+                "source_rpm_text": None,
+                "expected": None
+            },
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case=test_case["name"]):
+                advisory_nvra = test_case["advisory_nvra"]
+                is_source = test_case["is_source"]
+                source_rpm_text = test_case["source_rpm_text"]
+                expected = test_case["expected"]
+
+                package_name = None
+
+                if advisory_nvra.endswith(".src.rpm") or advisory_nvra.endswith(".src"):
+                    source_nvra = repomd.NVRA_RE.search(advisory_nvra)
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+                elif source_rpm_text:
+                    source_nvra = repomd.NVRA_RE.search(source_rpm_text)
+                    if source_nvra:
+                        package_name = source_nvra.group(1)
+
+                self.assertEqual(package_name, expected,
+                               f"Failed for {test_case['name']}: expected {expected}, got {package_name}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apollo/tests/test_rhcsaf.py
+++ b/apollo/tests/test_rhcsaf.py
@@ -52,7 +52,29 @@ class TestRedHatAdvisoryScraper(unittest.TestCase):
                                             "product_identification_helper": {
                                                 "cpe": "cpe:/o:redhat:enterprise_linux:9.4"
                                             }
-                                        }
+                                        },
+                                        "branches": [
+                                            {
+                                                "category": "product_version",
+                                                "name": "rsync-0:3.2.3-19.el9_4.1.x86_64",
+                                                "product": {
+                                                    "product_id": "rsync-0:3.2.3-19.el9_4.1.x86_64",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/rsync@3.2.3-19.el9_4.1?arch=x86_64"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "category": "product_version",
+                                                "name": "rsync-0:3.2.3-19.el9_4.1.src",
+                                                "product": {
+                                                    "product_id": "rsync-0:3.2.3-19.el9_4.1.src",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/rsync@3.2.3-19.el9_4.1?arch=src"
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -253,3 +275,226 @@ class TestExtractRhelAffectedProducts(unittest.TestCase):
             ("Red Hat Enterprise Linux", "Red Hat Enterprise Linux for x86_64", 9, None, "x86_64"),
             result
         )
+
+
+class TestEUSDetection(unittest.TestCase):
+    """Test EUS product detection and filtering"""
+
+    def setUp(self):
+        with patch('common.logger.Logger') as mock_logger_class:
+            mock_logger_class.return_value = MagicMock()
+            from apollo.rhcsaf import _is_eus_product
+            self._is_eus_product = _is_eus_product
+
+    def test_detect_eus_via_cpe(self):
+        """Test EUS detection via CPE product field"""
+        # EUS CPE products
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_eus:9.4::appstream"))
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_e4s:9.0::appstream"))
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_aus:8.2::appstream"))
+        self.assertTrue(self._is_eus_product("Some Product", "cpe:/a:redhat:rhel_tus:8.8::appstream"))
+
+        # Non-EUS CPE product
+        self.assertFalse(self._is_eus_product("Some Product", "cpe:/a:redhat:enterprise_linux:9::appstream"))
+
+    def test_detect_eus_via_name(self):
+        """Test EUS detection via product name keywords"""
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream EUS (v.9.4)", ""))
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream E4S (v.9.0)", ""))
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream AUS (v.8.2)", ""))
+        self.assertTrue(self._is_eus_product("Red Hat Enterprise Linux AppStream TUS (v.8.8)", ""))
+
+        # Non-EUS product name
+        self.assertFalse(self._is_eus_product("Red Hat Enterprise Linux AppStream", ""))
+
+    def test_eus_filtering_in_affected_products(self):
+        """Test that EUS products are filtered from affected products"""
+        csaf = {
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux AppStream EUS (v.9.4)",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        result = extract_rhel_affected_products_for_db(csaf)
+        # Should be empty because the only product is EUS
+        self.assertEqual(len(result), 0)
+
+
+class TestModularPackages(unittest.TestCase):
+    """Test modular package extraction"""
+
+    def test_extract_modular_packages(self):
+        """Test extraction of modular packages with ::module:stream suffix"""
+        csaf = {
+            "document": {
+                "tracking": {
+                    "initial_release_date": "2025-07-28T00:00:00+00:00",
+                    "current_release_date": "2025-07-28T00:00:00+00:00",
+                    "id": "RHSA-2025:12008"
+                },
+                "title": "Red Hat Security Advisory: Important: redis:7 security update",
+                "aggregate_severity": {"text": "Important"},
+                "notes": [
+                    {"category": "general", "text": "Test description"},
+                    {"category": "summary", "text": "Test topic"}
+                ]
+            },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "name": "Red Hat Enterprise Linux 9",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux 9",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/o:redhat:enterprise_linux:9::appstream"
+                                            }
+                                        },
+                                        "branches": [
+                                            {
+                                                "category": "product_version",
+                                                "name": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.x86_64::redis:7",
+                                                "product": {
+                                                    "product_id": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.x86_64::redis:7",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/redis@7.2.10-1.module+el9.6.0+23332+115a3b01?arch=x86_64&rpmmod=redis:7:9060020250716081121:9"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "category": "product_version",
+                                                "name": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.src::redis:7",
+                                                "product": {
+                                                    "product_id": "redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.src::redis:7",
+                                                    "product_identification_helper": {
+                                                        "purl": "pkg:rpm/redhat/redis@7.2.10-1.module+el9.6.0+23332+115a3b01?arch=src&rpmmod=redis:7:9060020250716081121:9"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2025-12345",
+                    "ids": [{"system_name": "Red Hat Bugzilla ID", "text": "123456"}],
+                    "product_status": {"fixed": []},
+                    "scores": [{"cvss_v3": {"vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "baseScore": 9.8}}],
+                    "cwe": {"id": "CWE-79"}
+                }
+            ]
+        }
+
+        result = red_hat_advisory_scraper(csaf)
+
+        # Check that modular packages were extracted with ::module:stream stripped
+        self.assertIn("redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.x86_64", result["red_hat_fixed_packages"])
+        self.assertIn("redis-0:7.2.10-1.module+el9.6.0+23332+115a3b01.src", result["red_hat_fixed_packages"])
+
+        # Verify epoch is preserved
+        for pkg in result["red_hat_fixed_packages"]:
+            if "redis" in pkg:
+                self.assertIn("0:", pkg, "Epoch should be preserved in NEVRA")
+
+
+class TestEUSAdvisoryFiltering(unittest.TestCase):
+    """Test that EUS-only advisories are filtered out"""
+
+    def test_eus_only_advisory_returns_none(self):
+        """Test that advisory with only EUS products returns None"""
+        csaf = {
+            "document": {
+                "tracking": {
+                    "initial_release_date": "2025-01-01T00:00:00+00:00",
+                    "current_release_date": "2025-01-01T00:00:00+00:00",
+                    "id": "RHSA-2025:9756"
+                },
+                "title": "Red Hat Security Advisory: Important: package security update",
+                "aggregate_severity": {"text": "Important"},
+                "notes": [
+                    {"category": "general", "text": "EUS advisory"},
+                    {"category": "summary", "text": "EUS topic"}
+                ]
+            },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_family",
+                                "name": "Red Hat Enterprise Linux",
+                                "branches": [
+                                    {
+                                        "category": "product_name",
+                                        "name": "Red Hat Enterprise Linux AppStream EUS (v.9.4)",
+                                        "product": {
+                                            "name": "Red Hat Enterprise Linux AppStream EUS (v.9.4)",
+                                            "product_identification_helper": {
+                                                "cpe": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "category": "architecture",
+                                "name": "x86_64"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2025-99999",
+                    "ids": [{"system_name": "Red Hat Bugzilla ID", "text": "999999"}],
+                    "product_status": {"fixed": []},
+                    "scores": [{"cvss_v3": {"vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "baseScore": 9.8}}],
+                    "cwe": {"id": "CWE-79"}
+                }
+            ]
+        }
+
+        result = red_hat_advisory_scraper(csaf)
+
+        # Advisory should be filtered out (return None) because all products are EUS
+        self.assertIsNone(result)


### PR DESCRIPTION
# Apollo Improvements: Bug Fixes, New Features, and API Enhancements

## Overview

This consolidated PR includes six related improvements to Apollo's errata management system, developed and thoroughly reviewed by CIQ across multiple PRs in a staging repository:

1. **Config generation flexibility** ([#15](https://github.com/rockythorn/distro-tools/pull/15)) - Enhanced version matching and naming for mirror configurations
2. **Modular package extraction** ([#16](https://github.com/rockythorn/distro-tools/pull/16)) - Fixed critical CSAF parsing bugs and added EUS filtering
3. **OSV API improvements** ([#17](https://github.com/rockythorn/distro-tools/pull/17)) - Return all CVE-containing advisories regardless of type
4. **Config import/export fixes** ([#18](https://github.com/rockythorn/distro-tools/pull/18)) - Fixed validation issues preventing environment sync
5. **Mirror management** ([#19](https://github.com/rockythorn/distro-tools/pull/19)) - Added active/inactive toggle for mirrors
6. **Updateinfo v2 endpoint** ([#20](https://github.com/rockythorn/distro-tools/pull/20)) - New API with FK-based filtering and module package fix

**Impact:** Fixes 230+ missing module advisories, adds major version aggregation, improves operational workflows, and enhances API completeness.

**Review Process:** Each PR was individually reviewed and approved by CIQ team members, with comprehensive testing and validation at each stage before being merged to the staging repository.

---

## 1. Config Generation Flexibility ([#15](https://github.com/rockythorn/distro-tools/pull/15))

### Problem
- `generate_rocky_config.py` required exact version matches, preventing generation of configs for RHEL 8/9 (which don't use minor versions in advisories)
- No way to customize mirror names for legacy products or special configurations

### Solution
**Flexible version matching:**
- `--version 9` matches all 9.x releases (generates NULL `match_minor_version`)
- `--version 10.2` matches only 10.2 (generates `match_minor_version: 2`)

**Custom naming:**
- `--mirror-name-base "Rocky Linux 9"` produces "Rocky Linux 9 x86_64" instead of "Rocky Linux 9.6 x86_64"
- Enables legacy product entries like "Rocky Linux 8.5 (Legacy)"

### Files Changed
- `scripts/generate_rocky_config.py`

**[Full details in PR #15 →](https://github.com/rockythorn/distro-tools/pull/15)**

---

## 2. Modular Package Extraction and EUS Filtering ([#16](https://github.com/rockythorn/distro-tools/pull/16))

### Problems
1. **Modular packages missing:** 12+ security advisories with modular packages (Redis, Node.js, etc.) had zero packages extracted
2. **EUS overhead:** ~50% of processed advisories were EUS/E4S/AUS/TUS-only and irrelevant to Rocky Linux
3. **CSV timestamp order:** Missing advisory updates because `releases.csv` was overwriting `changes.csv`

### Solutions
1. **New parser:** Added `_extract_packages_from_product_tree()` to handle modular CSAF format with `::module:stream` suffixes
2. **EUS filtering:** Added `_is_eus_product()` to detect and skip EUS products via CPE patterns and product names
3. **CSV merge fix:** Changed merge order to prioritize `changes.csv` over `releases.csv`
4. **Admin UI:** Added `/admin/workflows` interface for viewing/updating CSAF `last_indexed_at` timestamp

**Impact:**
- RHSA-2025:12008 (redis:7): 0 packages → 18 packages extracted
- 50% reduction in processed advisories
- Advisory updates now trigger reprocessing

### Files Changed
- `apollo/rhcsaf/__init__.py` - Parser refactor with modular/EUS handling
- `apollo/rhworker/poll_rh_activities.py` - CSV merge order fix
- `apollo/server/routes/admin_workflows.py` - New timestamp management UI
- `apollo/server/services/database_service.py` - Database methods
- `apollo/server/templates/admin_workflows.jinja` - UI template
- `apollo/tests/test_csaf_processing.py` - Fixed for Bazel
- `apollo/tests/test_rhcsaf.py` - 240 new lines (EUS/modular tests)
- `apollo/tests/test_database_service.py` - 226 new lines

**[Full details in PR #16 →](https://github.com/rockythorn/distro-tools/pull/16)**

---

## 3. OSV API Improvements ([#17](https://github.com/rockythorn/distro-tools/pull/17))

### Problem
OSV API filtered by `kind="Security"`, missing bug fix and enhancement advisories that contain CVEs.

### Solution
- Remove `kind` filter from queries
- Filter by CVE presence instead: `len(advisory.cves) > 0`
- Return 404 for advisories without CVEs (OSV is CVE-focused)

**Result:** All CVE-containing advisories now discoverable via OSV API, regardless of classification (RLSA, RLBA, RLEA).

### Files Changed
- `apollo/server/routes/api_osv.py` - Filter by CVE not kind
- `apollo/tests/test_api_osv.py` - 248 new lines

**[Full details in PR #17 →](https://github.com/rockythorn/distro-tools/pull/17)**

---

## 4. Config Import/Export Fixes ([#18](https://github.com/rockythorn/distro-tools/pull/18))

### Problems
1. **Float conversion:** Export serialized version numbers as floats (9.0), import rejected them (expects int)
2. **Parentheses rejected:** Validation regex didn't allow parentheses in names like "Rocky Linux 8.5 (Legacy)"

### Solutions
1. **Integer serialization:** Updated `_json_serializer()` to convert whole-number Decimals to int
2. **Name validation:** Updated `NAME_PATTERN` to include parentheses: `r"^[a-zA-Z0-9._\s()\-]+$"`

**Result:** Configs can be exported from production and imported to staging/dev without manual editing.

### Files Changed
- `apollo/server/routes/admin_supported_products.py` - Serializer fix
- `apollo/server/validation.py` - Allow parentheses
- `apollo/tests/test_admin_routes_supported_products.py` - Test updates

**[Full details in PR #18 →](https://github.com/rockythorn/distro-tools/pull/18)**

---

## 5. Mirror Active Field ([#19](https://github.com/rockythorn/distro-tools/pull/19))

### Problem
No way to disable mirrors without deleting them (loses historical data and advisory relationships).

### Solution
Added `active` boolean field to `supported_products_rh_mirrors`:
- Database migration with default TRUE (backward compatible)
- UI toggles in list/edit/create views with status indicators
- Workflow integration (RHMatcherWorkflow skips inactive mirrors)
- Export/import support

**Use cases:**
- Stage new mirrors before activation
- Temporarily disable problematic mirrors
- Deprecate old version mirrors while preserving history
- Test configurations without affecting production

### Files Changed
- `apollo/migrations/20251104111759_add_mirror_active_field.sql` - Migration
- `apollo/schema.sql` - Schema update
- `apollo/db/__init__.py` - ORM model
- `apollo/rpmworker/rh_matcher_activities.py` - Workflow filter
- `apollo/server/routes/admin_supported_products.py` - UI handlers
- `apollo/server/services/workflow_service.py` - Workflow list
- `apollo/server/templates/admin_supported_product*.jinja` - UI components (3 files)
- `apollo/tests/test_admin_routes_supported_products.py` - 217 new lines

**[Full details in PR #19 →](https://github.com/rockythorn/distro-tools/pull/19)**

---

## 6. Updateinfo V2 Endpoint and Module Package Fix ([#20](https://github.com/rockythorn/distro-tools/pull/20))

### Problems
1. **Module package source RPM mapping bug:** ~8,908 packages with "module." prefix in `package_name` field caused NEVRA mismatch
   - Database: "module.postgresql" vs NEVRA: "postgresql" → no match
   - **Impact:** 230+ module advisories missing from Rocky 8 AppStream updateinfo.xml

2. **V1 endpoint limitations:**
   - Denormalized filtering (string-based `product_name`)
   - No major version aggregation (separate XML per minor version)
   - URL encoding required for product names with spaces

### Solutions

#### ORM-Level Module Prefix Fix (Trinity Quirk)
Added Python property pattern to `AdvisoryPackage` model to transparently strip "module." prefix:

```python
class AdvisoryPackage(Model):
    _package_name = fields.TextField(source_field='package_name')

    @property
    def package_name(self):
        return self._clean_package_name(self._package_name)
```

- No database migration required
- Works for existing data (reads) and new data (writes)
- Transparent to all business logic

#### V2 Updateinfo API Endpoint
New endpoint: `/api/v3/updateinfo/{product_slug}/{major_version}/{repo}/updateinfo.xml?arch={arch}`

**Example:** `/api/v3/updateinfo/rocky-linux/8/BaseOS/updateinfo.xml?arch=x86_64`

**Key improvements:**
- FK-based filtering using `supported_product_id`
- Major version aggregation (8 → all 8.x minor versions)
- Required architecture parameter (validated against centralized `Architecture` enum)
- Product slug mapping (rocky-linux → Rocky Linux)
- Data integrity validation via FK relationships

#### Simplified Business Logic
Removed manual `.removeprefix("module.")` calls since ORM handles it automatically.

#### Architecture Validation
Replaced hardcoded architecture list with centralized `Architecture` enum from validation module.

### API Comparison

| Feature | V1 | V2 |
|---------|----|----|
| URL | `/Rocky%20Linux%208%20x86_64/BaseOS/updateinfo.xml` | `/rocky-linux/8/BaseOS/updateinfo.xml?arch=x86_64` |
| Filtering | String-based `product_name` | FK-based `supported_product_id` |
| Version aggregation | None (one-to-one) | Major version aggregation |
| Architecture | Optional query param | Required query param |
| URL encoding | Required (spaces) | Not needed (slugs) |

### Testing
- 14 new unit tests for helper functions
- Integration testing shows 230 module advisories now appear
- V1 endpoint produces identical output (backward compatible)
- Fixed source RPM version matching bug (el8_7 binary → el8_7 source, not el8_6)

### Files Changed
- `apollo/db/__init__.py` - ORM property pattern for module prefix
- `apollo/server/routes/api_updateinfo.py` - V2 endpoint, helpers, architecture validation
- `apollo/tests/test_api_updateinfo.py` - 182 new lines
- `apollo/tests/BUILD.bazel` - Add test target
- `.github/workflows/test.yaml` - Add test to CI

**[Full details in PR #20 →](https://github.com/rockythorn/distro-tools/pull/20)**

---

## Combined Statistics

### Test Coverage
- **New test files:** 3 (`test_api_osv.py`, `test_api_updateinfo.py`, `test_database_service.py`)
- **New test lines:** 900+ across all changes
- **Updated test files:** 2 (`test_csaf_processing.py`, `test_admin_routes_supported_products.py`)

### Code Changes
- **Files modified:** 25
- **Files added:** 8 (migrations, templates, tests)
- **Lines added:** ~2,000+
- **Lines modified/removed:** ~200

### Database Changes
- **Migrations:** 1 (`add_mirror_active_field`)
- **Schema updates:** `supported_products_rh_mirrors` table (added `active` boolean)
- **ORM changes:** Module prefix handling, active field

### Impact Summary
1. ✅ **230+ module advisories now included** in updateinfo.xml
2. ✅ **50% reduction** in advisory processing (EUS filtering)
3. ✅ **Major version aggregation** for v2 endpoint (single updateinfo for all 8.x, 9.X, 10.X)
4. ✅ **Complete OSV API** (all CVE-containing advisories)
5. ✅ **Zero-downtime mirror management** (active/inactive toggle)
6. ✅ **Environment sync** (export/import fixes)
7. ✅ **Operational flexibility** (config generation improvements)

---

## Deployment Notes

### Backward Compatibility
- ✅ All changes backward compatible
- ✅ V1 updateinfo endpoint unchanged
- ✅ Database migration adds field with default TRUE
- ✅ Existing configs import without modification

### Database Migration Required

**Migration file:** `apollo/migrations/20251104111759_add_mirror_active_field.sql`

### Optional Post-Deployment Actions
1. **Update CSAF timestamp** to reprocess recent modular advisories
2. **Regenerate RHEL 8/9 configs** with major-only version filtering
3. **Review and deactivate** any obsolete mirrors instead of deleting
4. **Clean up EUS advisories** from database (optional space savings)

### Breaking Changes
- OSV API now returns 404 for advisories without CVEs (previously returned advisory anyway)

---

## Testing Recommendations

1. **Modular advisories:** Verify RHSA-2025:12008 and similar now have packages
2. **V2 endpoint:** Test `/api/v3/updateinfo/rocky-linux/8/BaseOS/updateinfo.xml?arch=x86_64`
3. **OSV API:** Query for bug fix advisories with CVEs
4. **Config sync:** Export from one environment, import to another
5. **Mirror toggle:** Disable a mirror, verify workflow skips it
6. **Version matching:** Generate configs with `--version 9` (major only)

---

## Contributors

- Trinity Quirk - ORM module prefix fix
- Sam Thornton - All other changes


