### PR TITLE
Automate RhMatcherWorkflow execution to eliminate manual intervention in advisory generation pipeline

### DIFF
--- a/deploy/apollo/apollo-rpmworker/Chart.yaml
+++ b/deploy/apollo/apollo-rpmworker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/apollo/apollo-rpmworker/templates/cronjob.yaml
+++ b/deploy/apollo/apollo-rpmworker/templates/cronjob.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.cron.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "apollo-rpmworker.fullname" . }}
+  labels:
+    {{- include "apollo-rpmworker.labels" . | nindent 4 }}
+spec:
+  schedule: '{{ .Values.cron.schedule }}'
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          serviceAccountName: {{ include "apollo-rpmworker.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | indent 8 }}
+          activeDeadlineSeconds: 43200
+          containers:
+          - name: {{ .Chart.Name }}-rh-matcher-workflow
+            image: temporalio/admin-tools:1.10.5
+            securityContext:
+              {{- toYaml .Values.securityContext | indent 12 }}
+            env:
+              - name: TEMPORAL_CLI_ADDRESS
+                value: workflow-temporal-frontend.workflow.svc.cluster.local:7233
+            imagePullPolicy: IfNotPresent
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              {{- range $cmd := $.Values.cron.preCommand }}
+              {{ $cmd }}
+              {{- end }}
+              {{- if .Values.cron.majorVersions }}
+              tctl wf run --tq v2-rpmworker --wt RhMatcherWorkflow --input '{"major_versions": {{ .Values.cron.majorVersions | toJson }}}'
+              {{- else }}
+              tctl wf run --tq v2-rpmworker --wt RhMatcherWorkflow
+              {{- end }}
+              {{- range $cmd := $.Values.cron.postCommand }}
+              {{ $cmd }}
+              {{- end }}
+{{- end }}

--- a/deploy/apollo/apollo-rpmworker/values.yaml
+++ b/deploy/apollo/apollo-rpmworker/values.yaml
@@ -80,6 +80,17 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+cron:
+  enabled: true
+  schedule: "0 */6 * * *"
+  majorVersions: []
+  preCommand:
+    - trap 'curl --max-time 2 -s -f -XPOST http://127.0.0.1:15020/quitquitquit' EXIT
+    - while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done
+    - echo "Ready!"
+  postCommand:
+    - echo "Complete!"
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Adds Kubernetes CronJob that runs RhMatcherWorkflow every 6 hours, completing the final manual step in the Rocky Linux advisory automation. Follows the same pattern as the existing apollo-rhworker PollRHCSAFAdvisoriesWorkflow CronJob.