### PR TITLE
Fix updateinfo v2 timeout for RL8 AppStream by filtering prefetch

### DIFF
--- a/apollo/migrations/20260318000000_add_updateinfo_perf_indexes.sql
+++ b/apollo/migrations/20260318000000_add_updateinfo_perf_indexes.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+create index advisory_packages_advisory_repo_product_idx
+    on advisory_packages (advisory_id, repo_name, supported_product_id);
+
+create index advisory_affected_products_spid_major_arch_idx
+    on advisory_affected_products (supported_product_id, major_version, arch);
+
+
+-- migrate:down
+drop index if exists advisory_packages_advisory_repo_product_idx;
+drop index if exists advisory_affected_products_spid_major_arch_idx;

--- a/apollo/schema.sql
+++ b/apollo/schema.sql
@@ -1264,6 +1264,13 @@ CREATE INDEX advisory_affected_products_supported_product_idx ON public.advisory
 
 
 --
+-- Name: advisory_affected_products_spid_major_arch_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX advisory_affected_products_spid_major_arch_idx ON public.advisory_affected_products USING btree (supported_product_id, major_version, arch);
+
+
+--
 -- Name: advisory_affected_products_variantx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1296,6 +1303,13 @@ CREATE INDEX advisory_fixes_ticket_id ON public.advisory_fixes USING btree (tick
 --
 
 CREATE INDEX advisory_packages_advisory_id ON public.advisory_packages USING btree (advisory_id);
+
+
+--
+-- Name: advisory_packages_advisory_repo_product_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX advisory_packages_advisory_repo_product_idx ON public.advisory_packages USING btree (advisory_id, repo_name, supported_product_id);
 
 
 --

--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -5,8 +5,9 @@ from xml.etree import ElementTree as ET
 from fastapi import APIRouter, Response
 from slugify import slugify
 
-from apollo.db import AdvisoryAffectedProduct, SupportedProduct
+from apollo.db import AdvisoryAffectedProduct, AdvisoryPackage, SupportedProduct
 from tortoise.exceptions import DoesNotExist
+from tortoise.queryset import Prefetch
 from apollo.server.settings import COMPANY_NAME, MANAGING_EDITOR, UI_URL, get_setting
 from apollo.server.validation import Architecture
 
@@ -451,7 +452,13 @@ async def get_updateinfo_v2(
         "advisory",
         "advisory__cves",
         "advisory__fixes",
-        "advisory__packages",
+        Prefetch(
+            "advisory__packages",
+            queryset=AdvisoryPackage.filter(
+                repo_name=repo,
+                supported_product_id=supported_product.id,
+            ),
+        ),
         "supported_product",
     ).all()
 

--- a/apollo/tests/test_api_updateinfo.py
+++ b/apollo/tests/test_api_updateinfo.py
@@ -475,7 +475,8 @@ class TestUpdateinfoEndpoints(unittest.TestCase):
     @patch("apollo.server.routes.api_updateinfo.get_setting")
     @patch("apollo.server.routes.api_updateinfo.SupportedProduct")
     @patch("apollo.server.routes.api_updateinfo.AdvisoryAffectedProduct")
-    def test_get_updateinfo_v2_success(self, mock_aap, mock_sp, mock_get_setting):
+    @patch("apollo.server.routes.api_updateinfo.AdvisoryPackage")
+    def test_get_updateinfo_v2_success(self, mock_ap, mock_aap, mock_sp, mock_get_setting):
         """V2 endpoint returns valid XML with proper collection naming"""
         mock_get_setting.side_effect = self._mock_get_setting
 
@@ -526,7 +527,8 @@ class TestUpdateinfoEndpoints(unittest.TestCase):
 
     @patch("apollo.server.routes.api_updateinfo.SupportedProduct")
     @patch("apollo.server.routes.api_updateinfo.AdvisoryAffectedProduct")
-    def test_get_updateinfo_v2_no_advisories(self, mock_aap, mock_sp):
+    @patch("apollo.server.routes.api_updateinfo.AdvisoryPackage")
+    def test_get_updateinfo_v2_no_advisories(self, mock_ap, mock_aap, mock_sp):
         """V2 endpoint raises 404 when no advisories found"""
         mock_product = Mock()
         mock_product.id = 1
@@ -545,7 +547,8 @@ class TestUpdateinfoEndpoints(unittest.TestCase):
     @patch("apollo.server.routes.api_updateinfo.get_setting")
     @patch("apollo.server.routes.api_updateinfo.SupportedProduct")
     @patch("apollo.server.routes.api_updateinfo.AdvisoryAffectedProduct")
-    def test_get_updateinfo_v2_with_minor_version(self, mock_aap, mock_sp, mock_get_setting):
+    @patch("apollo.server.routes.api_updateinfo.AdvisoryPackage")
+    def test_get_updateinfo_v2_with_minor_version(self, mock_ap, mock_aap, mock_sp, mock_get_setting):
         """V2 endpoint filters by optional minor_version parameter"""
         mock_get_setting.side_effect = self._mock_get_setting
 


### PR DESCRIPTION
The `get_updateinfo_v2` endpoint was loading all `advisory_packages` rows for every matching advisory (all repos, arches, mirrors), then discarding ~95% of them in Python. For RL8 AppStream without a `minor_version` filter, this meant ~300k rows loaded to produce ~20k, consistently exceeding the 30-second server worker timeout.

## Changes

- Use `Prefetch` with a filtered queryset on `advisory__packages` so only packages matching the requested repo and `supported_product` are loaded from the DB
- Add composite index on `advisory_packages(advisory_id, repo_name, supported_product_id)` to support the filtered prefetch query
- Add composite index on `advisory_affected_products(supported_product_id, major_version, arch)` to speed up the initial filter query
- Add migration `20260318000000_add_updateinfo_perf_indexes.sql` to apply the new indexes to production

Closes #77

## Testing

Confirmed the endpoint was timing out on production before this fix:

| Endpoint | Status | Time |
|---|---|---|
| `RL8 AppStream x86_64` (production, pre-fix) | ❌ 500 | 28.9s |
| `RL8 AppStream aarch64` (production, pre-fix) | ❌ 500 | 29.4s |
| `RL8 BaseOS x86_64` (production, pre-fix) | ✅ 200 | 8.4s |

Local benchmarks were run against a DB restored from the April 2025 production dump (6,905 advisories, 384,990 packages) across three scenarios:

| Scenario | RL8 AppStream x86_64 | RL8 AppStream aarch64 | RL8 BaseOS x86_64 |
|---|---|---|---|
| main, no indexes (current production state) | ✅ 200 @ 8.3s | ✅ 200 @ 8.3s | ✅ 200 @ 1.6s |
| main, with indexes only | ✅ 200 @ 8.2s | ✅ 200 @ 8.2s | ✅ 200 @ 1.4s |
| fix branch, Prefetch + indexes | ✅ 200 @ 8.1s | ✅ 200 @ 8.1s | ✅ 200 @ 1.4s |

Local benchmarks did not reproduce the same timing differences seen in production. We suspect this is primarily due to local hardware being significantly faster than the Kubernetes cluster production runs on — the local machine's NVMe SSD likely masks the I/O cost that would be more pronounced on production storage under concurrent load.

`EXPLAIN ANALYZE` gives a more hardware-independent view, showing the new indexes reduce buffer reads by **12x**:

| | Buffers read | Buffers from cache |
|---|---|---|
| Without indexes | 5,604 | 11,529 |
| With indexes | 468 | 3,768 |

On production storage where data is less likely to be fully cached in memory, that 12x I/O reduction should translate directly into wall-clock time savings.