### PR TITLE
Fix NVRA regex parsing for EL10 packages

### DIFF
--- a/apollo/rpmworker/repomd.py
+++ b/apollo/rpmworker/repomd.py
@@ -11,13 +11,13 @@ import aiohttp
 import yaml
 
 NVRA_RE = re.compile(
-    r"^(\S+)-([\w~%.+^]+)-(\w+(?:\.[\w~%+]+)+?)(?:\.(\w+))?(?:\.rpm)?$"
+    r"^(\S+)-([\w~%.+^]+)-([\w~^]+(?:\.[\w~%+^]+)+?)(?:\.(\w+))?(?:\.rpm)?$"
 )
 NEVRA_RE = re.compile(
-    r"^(\S+)-(?:(\d)+:)([\w~%.+^]+)-(\w+(?:\.[\w~%+]+)+?)(?:\.(\w+))?(?:\.rpm)?$"
+    r"^(\S+)-(?:(\d)+:)([\w~%.+^]+)-([\w~^]+(?:\.[\w~%+^]+)+?)(?:\.(\w+))?(?:\.rpm)?$"
 )
 EPOCH_RE = re.compile(r"(\d+):")
-DIST_RE = re.compile(r"(\.el\d(?:_\d|))")
+DIST_RE = re.compile(r"(\.el\d+(?:_\d+|))")
 MODULE_DIST_RE = re.compile(r"\.module.+$")
 
 

--- a/apollo/rpmworker/rh_matcher_activities.py
+++ b/apollo/rpmworker/rh_matcher_activities.py
@@ -682,7 +682,13 @@ async def process_repomd(
         # becomes the package stripped of any module information
         # and with the nvra prepended with 'module.'
         cleaned, raw = repomd.clean_nvra_pkg(pkg)
-        name = repomd.NVRA_RE.search(cleaned).group(1)
+        match = repomd.NVRA_RE.search(cleaned)
+        if not match:
+            logger.warning(
+                "Skipping package with unrecognized NVRA: %s", cleaned
+            )
+            continue
+        name = match.group(1)
 
         if cleaned not in raw_pkg_nvras:
             raw_pkg_nvras[cleaned] = []


### PR DESCRIPTION
## Summary

- `DIST_RE` only matched single-digit EL versions (`\.el\d`), so `.el10` was partially stripped as `.el1`, corrupting releases like `1.el10~bootstrap` into `10~bootstrap`
- `NVRA_RE` / `NEVRA_RE` release groups started with `\w+` which excludes `~` and `^`, so cleaned releases containing RPM tilde suffixes (e.g. `1~bootstrap`) could not match
- Both bugs compound to crash the `match_rh_repos` activity in `process_repomd` when processing Rocky 10.2 repos containing packages like `qt6-qtremoteobjects` with release `1.el10~bootstrap`

## Changes

- `DIST_RE`: `\d` → `\d+` to handle multi-digit EL versions (10+)
- `NVRA_RE` / `NEVRA_RE`: release initial segment `\w+` → `[\w~^]+` to accept RPM tilde/caret suffixes
- Guard `NVRA_RE.search()` in `process_repomd` to log a warning and skip instead of crashing the whole activity on unrecognized NVRAs

## Test plan

- [x] All 12 existing tests pass
- [x] Verified fix against 10,956 packages across Rocky 10.2 AppStream and BaseOS repos (0 failures)
- [x] Reproduced production traceback locally, confirmed it no longer occurs after fix