### PR TITLE
Add CC-BY-4.0 attribution for Red Hat-sourced advisory content

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,8 @@ jobs:
         bazel test //apollo/tests:test_admin_routes_supported_products --test_output=all
         bazel test //apollo/tests:test_admin_users --test_output=all
         bazel test //apollo/tests:test_api_osv --test_output=all
+        bazel test //apollo/tests:test_api_compat --test_output=all
+        bazel test //apollo/tests:test_api_advisories --test_output=all
         bazel test //apollo/tests:test_database_service --test_output=all
         bazel test //apollo/tests:test_rh_matcher_activities --test_output=all
 

--- a/apollo/db/advisory.py
+++ b/apollo/db/advisory.py
@@ -124,6 +124,7 @@ async def fetch_advisories(
     if fetch_related:
         for advisory in advisories:
             await advisory.fetch_related(
+                "red_hat_advisory",
                 "packages",
                 "cves",
                 "fixes",

--- a/apollo/db/serialize/__init__.py
+++ b/apollo/db/serialize/__init__.py
@@ -85,6 +85,14 @@ class Advisory_Pydantic_V2_CVE(BaseModel):
     cwe: Optional[str]
 
 
+class Advisory_Pydantic_V2_Source(BaseModel):
+    name: str
+    url: str
+    vendor: str
+    license: str
+    licenseUrl: str
+
+
 class Advisory_Pydantic_V2(BaseModel):
     type: str
     shortCode: str
@@ -102,6 +110,11 @@ class Advisory_Pydantic_V2(BaseModel):
     rpms: dict[str, Advisory_Pydantic_V2_RPMs]
     rebootSuggested: bool
     buildReferences: list[str]
+    source: Optional[Advisory_Pydantic_V2_Source] = None
 
     class Config:
         orm_mode = True
+
+
+class Advisory_Pydantic_WithSource(Advisory_Pydantic):
+    source: Optional[Advisory_Pydantic_V2_Source] = None

--- a/apollo/server/BUILD.bazel
+++ b/apollo/server/BUILD.bazel
@@ -4,6 +4,7 @@ load("//build/macros:fastapi.bzl", "fastapi_binary")
 py_library(
     name = "server_lib",
     srcs = [
+        "attribution.py",
         "auth.py",
         "models/__init__.py",
         "models/workflow.py",

--- a/apollo/server/attribution.py
+++ b/apollo/server/attribution.py
@@ -1,0 +1,52 @@
+"""Attribution for Red Hat-sourced advisory content.
+
+Rocky advisories re-publish Red Hat advisory content, which Red Hat licenses
+under CC BY 4.0. That license requires crediting the source, linking to the
+original advisory and to the license, and indicating that changes were made.
+These helpers keep that notice identical across every output format
+(updateinfo.xml, the v2 API, OSV, and the web UI).
+"""
+
+SOURCE_VENDOR = "Red Hat"
+SOURCE_LICENSE = "CC-BY-4.0"
+LICENSE_NAME = "CC BY 4.0"
+SOURCE_LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/"
+RED_HAT_ERRATA_BASE_URL = "https://access.redhat.com/errata"
+
+
+def red_hat_errata_url(red_hat_advisory_name: str) -> str:
+    """Return the canonical Red Hat errata URL for a given advisory name."""
+    return f"{RED_HAT_ERRATA_BASE_URL}/{red_hat_advisory_name}"
+
+
+def source_fields(red_hat_advisory_name: str) -> dict:
+    """Return the structured source/license fields for a Red Hat-derived advisory."""
+    return {
+        "name": red_hat_advisory_name,
+        "url": red_hat_errata_url(red_hat_advisory_name),
+        "vendor": SOURCE_VENDOR,
+        "license": SOURCE_LICENSE,
+        "licenseUrl": SOURCE_LICENSE_URL,
+    }
+
+
+def attribution_rights(
+    red_hat_advisory_name: str, company_name: str, year: int
+) -> str:
+    """Build the per-advisory rights line crediting the Red Hat source under CC BY 4.0."""
+    url = red_hat_errata_url(red_hat_advisory_name)
+    return (
+        f"Copyright {year} {company_name}. "
+        f"Advisory content derived from {SOURCE_VENDOR} {red_hat_advisory_name} "
+        f"({url}), © {SOURCE_VENDOR}, Inc., used under {LICENSE_NAME} "
+        f"({SOURCE_LICENSE_URL}), with modifications."
+    )
+
+
+def attribution_notice() -> str:
+    """Build a source-agnostic attribution line for feed and site-wide use."""
+    return (
+        f"Advisory content is derived from {SOURCE_VENDOR} advisories, "
+        f"© {SOURCE_VENDOR}, Inc., used under {LICENSE_NAME} "
+        f"({SOURCE_LICENSE_URL}), with modifications."
+    )

--- a/apollo/server/routes/api_advisories.py
+++ b/apollo/server/routes/api_advisories.py
@@ -4,10 +4,15 @@ from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 from fastapi_pagination import Params
 from fastapi_pagination.links import Page
-from fastapi_pagination.ext.tortoise import paginate
+from fastapi_pagination.ext.tortoise import create_page
 
 from apollo.db import Advisory, RedHatIndexState
-from apollo.db.serialize import Advisory_Pydantic
+from apollo.db.serialize import (
+    Advisory_Pydantic,
+    Advisory_Pydantic_V2_Source,
+    Advisory_Pydantic_WithSource,
+)
+from apollo.server import attribution
 
 router = APIRouter(tags=["advisories"])
 
@@ -22,9 +27,24 @@ class Pagination(Page[T], Generic[T]):
         fields = {"items": {"alias": "advisories"}}
 
 
+def _advisory_source(advisory: Advisory) -> Optional[Advisory_Pydantic_V2_Source]:
+    if not advisory.red_hat_advisory_id:
+        return None
+    return Advisory_Pydantic_V2_Source(
+        **attribution.source_fields(advisory.red_hat_advisory.name)
+    )
+
+
+async def _advisory_with_source(advisory: Advisory) -> Advisory_Pydantic_WithSource:
+    base = await Advisory_Pydantic.from_tortoise_orm(advisory)
+    return Advisory_Pydantic_WithSource(
+        **base.dict(), source=_advisory_source(advisory)
+    )
+
+
 @router.get(
     "/",
-    response_model=Pagination[Advisory_Pydantic],
+    response_model=Pagination[Advisory_Pydantic_WithSource],
 )
 async def list_advisories(
     params: Params = Depends(),
@@ -37,15 +57,18 @@ async def list_advisories(
     severity: Optional[str] = None,
     kind: Optional[str] = None,
 ):
-    advisories = await paginate(
-        Advisory.all().prefetch_related(
-            "red_hat_advisory",
-            "packages",
-            "cves",
-            "fixes",
-            "affected_products",
-        ).order_by("-published_at"),
-    )
+    query = Advisory.all().prefetch_related(
+        "red_hat_advisory",
+        "packages",
+        "cves",
+        "fixes",
+        "affected_products",
+    ).order_by("-published_at")
+
+    total = await query.count()
+    page_orm = await query.offset(params.size * (params.page - 1)).limit(params.size)
+    items = [await _advisory_with_source(adv) for adv in page_orm]
+    advisories = create_page(items, total, params)
 
     state = await RedHatIndexState.first()
     advisories.last_updated_at = state.last_indexed_at.isoformat("T").replace(
@@ -58,10 +81,11 @@ async def list_advisories(
 
 @router.get(
     "/{advisory_name}",
-    response_model=Advisory_Pydantic,
+    response_model=Advisory_Pydantic_WithSource,
 )
 async def get_advisory(advisory_name: str):
     advisory = await Advisory.filter(name=advisory_name).prefetch_related(
+        "red_hat_advisory",
         "packages",
         "cves",
         "fixes",
@@ -74,4 +98,4 @@ async def get_advisory(advisory_name: str):
     if advisory is None:
         raise HTTPException(404)
 
-    return await Advisory_Pydantic.from_tortoise_orm(advisory)
+    return await _advisory_with_source(advisory)

--- a/apollo/server/routes/api_compat.py
+++ b/apollo/server/routes/api_compat.py
@@ -19,7 +19,8 @@ from rssgen.feed import RssGenerator
 
 from apollo.db import Advisory, RedHatIndexState
 from apollo.db.advisory import fetch_advisories
-from apollo.db.serialize import Advisory_Pydantic_V2, Advisory_Pydantic_V2_CVE, Advisory_Pydantic_V2_Fix, Advisory_Pydantic_V2_RPMs
+from apollo.db.serialize import Advisory_Pydantic_V2, Advisory_Pydantic_V2_CVE, Advisory_Pydantic_V2_Fix, Advisory_Pydantic_V2_RPMs, Advisory_Pydantic_V2_Source
+from apollo.server import attribution
 from apollo.server.settings import UI_URL, COMPANY_NAME, MANAGING_EDITOR, get_setting
 
 from common.fastapi import RenderErrorTemplateException, parse_rfc3339_date
@@ -137,6 +138,12 @@ def v3_advisory_to_v2(
     if severity == "NONE":
         severity = "UNKNOWN"
 
+    source = None
+    if fetch_related and advisory.red_hat_advisory_id:
+        source = Advisory_Pydantic_V2_Source(
+            **attribution.source_fields(advisory.red_hat_advisory.name)
+        )
+
     return Advisory_Pydantic_V2(
         id=advisory.id,
         publishedAt=published_at,
@@ -155,6 +162,7 @@ def v3_advisory_to_v2(
         buildReferences=[],
         fixes=fixes,
         cves=cves,
+        source=source,
     )
 
 
@@ -307,7 +315,9 @@ async def list_advisories_compat_v2_rss(
     fg.language("en")
     fg.description(f"Advisories issued by {company_name}")
     fg.copyright(
-        f"(C) {company_name} {datetime.datetime.now().year}. All rights reserved. CVE sources are copyright of their respective owners."
+        f"(C) {company_name} {datetime.datetime.now().year}. All rights reserved. "
+        f"CVE sources are copyright of their respective owners. "
+        f"{attribution.attribution_notice()}"
     )
     fg.managingEditor(f"{managing_editor} ({company_name})")
 
@@ -332,6 +342,7 @@ async def list_advisories_compat_v2_rss(
 )
 async def get_advisory_compat_v2(advisory_name: str):
     advisory = await Advisory.filter(name=advisory_name).prefetch_related(
+        "red_hat_advisory",
         "packages",
         "cves",
         "fixes",

--- a/apollo/server/routes/api_osv.py
+++ b/apollo/server/routes/api_osv.py
@@ -12,6 +12,7 @@ from slugify import slugify
 from apollo.db import Advisory, RedHatIndexState
 from apollo.db.advisory import fetch_advisories
 from apollo.rpmworker.repomd import EPOCH_RE, NEVRA_RE
+from apollo.server import attribution
 from apollo.server.settings import UI_URL, get_setting
 
 from common.fastapi import Params, to_rfc3339_date
@@ -85,7 +86,9 @@ class OSVCredit(BaseModel):
 
 
 class OSVDatabaseSpecific(BaseModel):
-    pass
+    license: Optional[str] = None
+    license_url: Optional[str] = None
+    source_advisory: Optional[str] = None
 
 
 class OSVAdvisory(BaseModel):
@@ -194,8 +197,21 @@ def to_osv_advisory(ui_url: str, advisory: Advisory) -> OSVAdvisory:
         references.append(OSVReference(type="REPORT", url=fix.source))
 
     osv_credits = [OSVCredit(name=x) for x in vendors]
-    if advisory.red_hat_advisory:
-        osv_credits.append(OSVCredit(name="Red Hat"))
+    database_specific = None
+    red_hat_advisory = advisory.red_hat_advisory
+    if red_hat_advisory:
+        references.append(
+            OSVReference(
+                type="ADVISORY",
+                url=attribution.red_hat_errata_url(red_hat_advisory.name),
+            )
+        )
+        osv_credits.append(OSVCredit(name=attribution.SOURCE_VENDOR))
+        database_specific = OSVDatabaseSpecific(
+            license=attribution.SOURCE_LICENSE,
+            license_url=attribution.SOURCE_LICENSE_URL,
+            source_advisory=red_hat_advisory.name,
+        )
 
     highest_cvss_base_score = 0.0
     final_score_vector = None
@@ -225,7 +241,7 @@ def to_osv_advisory(ui_url: str, advisory: Advisory) -> OSVAdvisory:
         affected=affected_pkgs,
         references=references,
         credits=osv_credits,
-        database_specific=None,
+        database_specific=database_specific,
     )
 
 
@@ -280,6 +296,7 @@ async def get_advisory_osv(advisory_id: str):
     advisory = (
         await Advisory.filter(name=advisory_id)
         .prefetch_related(
+            "red_hat_advisory",
             "packages",
             "cves",
             "fixes",

--- a/apollo/server/routes/api_updateinfo.py
+++ b/apollo/server/routes/api_updateinfo.py
@@ -8,6 +8,7 @@ from slugify import slugify
 from apollo.db import AdvisoryAffectedProduct, AdvisoryPackage, SupportedProduct
 from tortoise.exceptions import DoesNotExist
 from tortoise.queryset import Prefetch
+from apollo.server import attribution
 from apollo.server.settings import COMPANY_NAME, MANAGING_EDITOR, UI_URL, get_setting
 from apollo.server.validation import Architecture
 
@@ -151,9 +152,13 @@ def generate_updateinfo_xml(
         updated.set("date", advisory.updated_at.strftime(time_format))
 
         now = datetime.datetime.utcnow()
-        ET.SubElement(
-            update, "rights"
-        ).text = f"Copyright {now.year} {company_name}"
+        if advisory.red_hat_advisory_id:
+            rights_text = attribution.attribution_rights(
+                advisory.red_hat_advisory.name, company_name, now.year
+            )
+        else:
+            rights_text = f"Copyright {now.year} {company_name}"
+        ET.SubElement(update, "rights").text = rights_text
 
         release_name = f"{supported_product_name} {major_version}"
         if minor_version:
@@ -189,6 +194,20 @@ def generate_updateinfo_xml(
         reference.set("id", advisory.name)
         reference.set("type", "self")
         reference.set("title", advisory.name)
+
+        if advisory.red_hat_advisory_id:
+            rh_name = advisory.red_hat_advisory.name
+            source_ref = ET.SubElement(references, "reference")
+            source_ref.set("href", attribution.red_hat_errata_url(rh_name))
+            source_ref.set("id", rh_name)
+            source_ref.set("type", "vendor")
+            source_ref.set("title", f"{attribution.SOURCE_VENDOR} {rh_name}")
+
+            license_ref = ET.SubElement(references, "reference")
+            license_ref.set("href", attribution.SOURCE_LICENSE_URL)
+            license_ref.set("id", attribution.SOURCE_LICENSE)
+            license_ref.set("type", "other")
+            license_ref.set("title", f"License: {attribution.SOURCE_LICENSE}")
 
         packages_element = ET.SubElement(update, "pkglist")
 
@@ -353,6 +372,7 @@ async def get_updateinfo(
         **filters
     ).prefetch_related(
         "advisory",
+        "advisory__red_hat_advisory",
         "advisory__cves",
         "advisory__fixes",
         "advisory__packages",
@@ -450,6 +470,7 @@ async def get_updateinfo_v2(
         **filters
     ).prefetch_related(
         "advisory",
+        "advisory__red_hat_advisory",
         "advisory__cves",
         "advisory__fixes",
         Prefetch(

--- a/apollo/server/templates/advisory.jinja
+++ b/apollo/server/templates/advisory.jinja
@@ -35,6 +35,14 @@
     </h5>
     <h5 style="font-weight:500">Updated at: <span style="font-weight:400;">{{ advisory.updated_at.date() }}</span></h5>
   </div>
+  {% if advisory.red_hat_advisory_id %}
+  <p style="padding-top:0.5rem;font-size:var(--cds-body-short-01-font-size);color:var(--cds-text-02);">
+    Advisory content derived from
+    <a target="_blank" href="{{ attribution.red_hat_errata_url(advisory.red_hat_advisory.name) }}">{{ attribution.SOURCE_VENDOR }} {{ advisory.red_hat_advisory.name }}</a>,
+    &copy; {{ attribution.SOURCE_VENDOR }}, Inc., used under
+    <a target="_blank" href="{{ attribution.SOURCE_LICENSE_URL }}">{{ attribution.LICENSE_NAME }}</a>, with modifications.
+  </p>
+  {% endif %}
 </div>
 
 <div class="bx--grid bx--grid--full-width" style="margin:3rem 0;">

--- a/apollo/server/utils.py
+++ b/apollo/server/utils.py
@@ -4,6 +4,7 @@ from passlib.context import CryptContext
 import os
 
 from apollo.db import User
+from apollo.server import attribution
 from apollo.server.roles import ADMIN
 
 from common.fastapi import RenderErrorTemplateException
@@ -27,6 +28,7 @@ def get_environment_info():
     }
 
 templates.env.globals["get_environment_info"] = get_environment_info
+templates.env.globals["attribution"] = attribution
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/apollo/tests/BUILD.bazel
+++ b/apollo/tests/BUILD.bazel
@@ -88,6 +88,23 @@ py_test(
 )
 
 py_test(
+    name = "test_api_compat",
+    srcs = ["test_api_compat.py"],
+    deps = [
+        "//apollo/server:server_lib",
+    ],
+)
+
+py_test(
+    name = "test_api_advisories",
+    srcs = ["test_api_advisories.py"],
+    deps = [
+        "//apollo/server:server_lib",
+        "@pypi_httpx//:pkg",
+    ],
+)
+
+py_test(
     name = "test_database_service",
     srcs = ["test_database_service.py"],
     deps = [

--- a/apollo/tests/test_api_advisories.py
+++ b/apollo/tests/test_api_advisories.py
@@ -1,0 +1,217 @@
+"""
+Tests for the v3 advisories API source attribution helper and the
+offset/limit pagination used by the advisory list endpoint.
+"""
+
+import datetime
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_pagination import add_pagination
+
+from apollo.db.serialize import Advisory_Pydantic_WithSource
+from apollo.server.routes import api_advisories
+from apollo.server.routes.api_advisories import _advisory_source
+
+
+def _mock_advisory(red_hat_advisory_name="RHSA-2026:18480"):
+    advisory = Mock()
+    if red_hat_advisory_name:
+        red_hat_advisory = Mock()
+        red_hat_advisory.name = red_hat_advisory_name
+        advisory.red_hat_advisory = red_hat_advisory
+        advisory.red_hat_advisory_id = 1
+    else:
+        advisory.red_hat_advisory = None
+        advisory.red_hat_advisory_id = None
+    return advisory
+
+
+class TestAdvisorySource(unittest.TestCase):
+    """Test the v3 JSON source object derivation"""
+
+    def test_source_from_red_hat_advisory(self):
+        source = _advisory_source(_mock_advisory("RHSA-2026:18480"))
+        self.assertIsNotNone(source)
+        self.assertEqual(source.name, "RHSA-2026:18480")
+        self.assertEqual(
+            source.url, "https://access.redhat.com/errata/RHSA-2026:18480"
+        )
+        self.assertEqual(source.vendor, "Red Hat")
+        self.assertEqual(source.license, "CC-BY-4.0")
+        self.assertEqual(
+            source.licenseUrl, "https://creativecommons.org/licenses/by/4.0/"
+        )
+
+    def test_no_source_when_red_hat_advisory_absent(self):
+        # red_hat_advisory_id is nullable in the DB, so this path is reachable.
+        self.assertIsNone(_advisory_source(_mock_advisory(red_hat_advisory_name=None)))
+
+
+TOTAL_ADVISORIES = 25
+LAST_INDEXED_AT = datetime.datetime(
+    2026, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc
+)
+
+
+class FakeQuerySet:
+    """
+    Stands in for a Tortoise queryset over a fixed list of rows.
+
+    Mirrors the parts of the queryset API that the list endpoint uses:
+    ``offset``/``limit`` return a new queryset (they do not mutate the
+    receiver), awaiting the queryset yields the requested slice, and
+    ``count`` reports the size of the unsliced result set.
+    """
+
+    def __init__(self, rows, offset=0, limit=None):
+        self.rows = rows
+        self._offset = offset
+        self._limit = limit
+
+    def prefetch_related(self, *_relations):
+        return self
+
+    def order_by(self, *_fields):
+        return self
+
+    def offset(self, offset):
+        return FakeQuerySet(self.rows, offset, self._limit)
+
+    def limit(self, limit):
+        return FakeQuerySet(self.rows, self._offset, limit)
+
+    async def count(self):
+        return len(self.rows)
+
+    def __await__(self):
+        return self._fetch().__await__()
+
+    async def _fetch(self):
+        end = None if self._limit is None else self._offset + self._limit
+        return self.rows[self._offset:end]
+
+
+def _advisory_rows(count):
+    rows = []
+    for index in range(1, count + 1):
+        row = Mock(id=index)
+        row.name = f"RLSA-2026:{index:04d}"
+        rows.append(row)
+    return rows
+
+
+async def _fake_advisory_with_source(advisory):
+    return Advisory_Pydantic_WithSource(
+        id=advisory.id,
+        created_at=LAST_INDEXED_AT,
+        published_at=LAST_INDEXED_AT,
+        name=advisory.name,
+        synopsis="synopsis",
+        description="description",
+        kind="Security Advisory",
+        severity="Important",
+        topic="topic",
+    )
+
+
+class TestListAdvisoriesPagination(unittest.TestCase):
+    """Test the offset/limit pagination of the advisory list endpoint"""
+
+    def setUp(self):
+        self.rows = _advisory_rows(TOTAL_ADVISORIES)
+
+        advisory_patch = patch.object(api_advisories, "Advisory")
+        advisory_cls = advisory_patch.start()
+        advisory_cls.all.return_value = FakeQuerySet(self.rows)
+        self.addCleanup(advisory_patch.stop)
+
+        state = Mock()
+        state.last_indexed_at = LAST_INDEXED_AT
+        state_patch = patch.object(api_advisories, "RedHatIndexState")
+        state_patch.start().first = AsyncMock(return_value=state)
+        self.addCleanup(state_patch.stop)
+
+        serializer_patch = patch.object(
+            api_advisories,
+            "_advisory_with_source",
+            side_effect=_fake_advisory_with_source,
+        )
+        serializer_patch.start()
+        self.addCleanup(serializer_patch.stop)
+
+        app = FastAPI()
+        app.include_router(api_advisories.router)
+        add_pagination(app)
+        self.client = TestClient(app)
+
+    def _get_page(self, **params):
+        response = self.client.get("/", params=params)
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    @staticmethod
+    def _names(body):
+        return [advisory["name"] for advisory in body["advisories"]]
+
+    def test_default_params_return_first_page(self):
+        body = self._get_page()
+
+        self.assertEqual(body["page"], 1)
+        self.assertEqual(body["size"], 50)
+        self.assertEqual(body["total"], TOTAL_ADVISORIES)
+        self.assertEqual(len(body["advisories"]), TOTAL_ADVISORIES)
+
+    def test_first_page_starts_at_the_first_row(self):
+        body = self._get_page(page=1, size=10)
+
+        self.assertEqual(self._names(body), self._names_for(0, 10))
+        self.assertEqual(body["page"], 1)
+        self.assertEqual(body["size"], 10)
+
+    def test_second_page_is_offset_by_one_page_size(self):
+        body = self._get_page(page=2, size=10)
+
+        self.assertEqual(self._names(body), self._names_for(10, 20))
+        self.assertEqual(body["page"], 2)
+
+    def test_final_page_is_partial(self):
+        body = self._get_page(page=3, size=10)
+
+        self.assertEqual(self._names(body), self._names_for(20, 25))
+        self.assertEqual(len(body["advisories"]), 5)
+
+    def test_page_past_the_end_is_empty(self):
+        body = self._get_page(page=4, size=10)
+
+        self.assertEqual(body["advisories"], [])
+        self.assertEqual(body["total"], TOTAL_ADVISORIES)
+
+    def test_total_counts_the_result_set_not_the_page(self):
+        body = self._get_page(page=1, size=10)
+
+        self.assertEqual(body["total"], TOTAL_ADVISORIES)
+        self.assertEqual(len(body["advisories"]), 10)
+
+    def test_paging_through_covers_every_advisory_exactly_once(self):
+        size = 7
+        seen = []
+        for page in range(1, 5):
+            seen.extend(self._names(self._get_page(page=page, size=size)))
+
+        self.assertEqual(seen, [row.name for row in self.rows])
+        self.assertEqual(len(set(seen)), TOTAL_ADVISORIES)
+
+    def test_last_updated_at_reports_the_index_state(self):
+        body = self._get_page(page=1, size=10)
+
+        self.assertEqual(body["last_updated_at"], "2026-01-02T03:04:05Z")
+
+    def _names_for(self, start, end):
+        return [row.name for row in self.rows[start:end]]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apollo/tests/test_api_compat.py
+++ b/apollo/tests/test_api_compat.py
@@ -1,0 +1,100 @@
+"""
+Tests for the v2 compatibility API serialization (advisory source attribution)
+"""
+
+import unittest
+import datetime
+from unittest.mock import Mock
+
+from apollo.server.routes.api_compat import v3_advisory_to_v2
+from apollo.server import attribution
+from apollo.db.serialize import Advisory_Pydantic, Advisory_Pydantic_WithSource
+
+
+def create_mock_advisory(red_hat_advisory_name="RHSA-2024:1234"):
+    """Create a mock advisory sufficient for v3_advisory_to_v2 serialization"""
+    advisory = Mock()
+    advisory.id = 1
+    advisory.name = "RLSA-2024:1234"
+    advisory.synopsis = "Important: kernel security update"
+    advisory.description = "An update for kernel is now available."
+    advisory.kind = "Security"
+    advisory.severity = "Important"
+    advisory.topic = "An update is available"
+    advisory.published_at = datetime.datetime(2024, 1, 15, 10, 0, 0)
+    advisory.affected_products = []
+    advisory.cves = []
+    advisory.fixes = []
+    advisory.packages = []
+    if red_hat_advisory_name:
+        red_hat_advisory = Mock()
+        red_hat_advisory.name = red_hat_advisory_name
+        advisory.red_hat_advisory = red_hat_advisory
+        advisory.red_hat_advisory_id = 1
+    else:
+        advisory.red_hat_advisory = None
+        advisory.red_hat_advisory_id = None
+    return advisory
+
+
+class TestV2AdvisorySource(unittest.TestCase):
+    """Test that the v2 advisory payload carries Red Hat source attribution"""
+
+    def test_source_populated_from_red_hat_advisory(self):
+        """source carries the RHSA name/url, vendor, and CC BY 4.0 license"""
+        result = v3_advisory_to_v2(
+            create_mock_advisory(), include_rpms=False, fetch_related=True
+        )
+        self.assertIsNotNone(result.source)
+        self.assertEqual(result.source.name, "RHSA-2024:1234")
+        self.assertEqual(
+            result.source.url, "https://access.redhat.com/errata/RHSA-2024:1234"
+        )
+        self.assertEqual(result.source.vendor, "Red Hat")
+        self.assertEqual(result.source.license, "CC-BY-4.0")
+        self.assertEqual(
+            result.source.licenseUrl,
+            "https://creativecommons.org/licenses/by/4.0/",
+        )
+
+    def test_source_absent_without_related_fetch(self):
+        """The lightweight list path (fetchRelated=false) omits source"""
+        result = v3_advisory_to_v2(
+            create_mock_advisory(), include_rpms=False, fetch_related=False
+        )
+        self.assertIsNone(result.source)
+
+    def test_source_absent_without_red_hat_advisory(self):
+        """Advisories with no Red Hat source have no source block"""
+        result = v3_advisory_to_v2(
+            create_mock_advisory(red_hat_advisory_name=None),
+            include_rpms=False,
+            fetch_related=True,
+        )
+        self.assertIsNone(result.source)
+
+
+class TestSourceFieldsAndModels(unittest.TestCase):
+    """Test the shared source helper and the v3 JSON source-bearing model"""
+
+    def test_source_fields(self):
+        self.assertEqual(
+            attribution.source_fields("RHSA-2026:1234"),
+            {
+                "name": "RHSA-2026:1234",
+                "url": "https://access.redhat.com/errata/RHSA-2026:1234",
+                "vendor": "Red Hat",
+                "license": "CC-BY-4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+            },
+        )
+
+    def test_base_model_excludes_red_hat_advisory(self):
+        self.assertNotIn("red_hat_advisory", Advisory_Pydantic.__fields__)
+
+    def test_with_source_model_adds_source(self):
+        self.assertIn("source", Advisory_Pydantic_WithSource.__fields__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apollo/tests/test_api_osv.py
+++ b/apollo/tests/test_api_osv.py
@@ -63,6 +63,13 @@ class MockFix:
         self.source = source
 
 
+class MockRedHatAdvisory:
+    """Mock RedHatAdvisory model (the source advisory)"""
+
+    def __init__(self, name="RHSA-2024:1234"):
+        self.name = name
+
+
 class MockAdvisory:
     """Mock Advisory model"""
 
@@ -242,6 +249,54 @@ class TestOSVCVEFiltering(unittest.TestCase):
 
         fixed_version = result.affected[0].ranges[0].events[1].fixed
         self.assertEqual(fixed_version, "0:252-38.el9_5")
+
+
+class TestOSVAttribution(unittest.TestCase):
+    """Test Red Hat source attribution and CC BY 4.0 license in OSV output"""
+
+    def _advisory(self, red_hat_advisory):
+        packages = [
+            MockPackage(
+                nevra="pcs-0:0.11.8-2.el9_5.src",
+                supported_products_rh_mirror=MockSupportedProductsRhMirror(9),
+            ),
+        ]
+        return MockAdvisory(
+            packages=packages,
+            cves=[MockCVE()],
+            red_hat_advisory=red_hat_advisory,
+        )
+
+    def test_red_hat_source_reference_and_license(self):
+        """Output references the source RHSA and records the CC BY 4.0 license"""
+        advisory = self._advisory(MockRedHatAdvisory("RHSA-2024:1234"))
+        result = to_osv_advisory("https://errata.rockylinux.org", advisory)
+
+        urls = [r.url for r in result.references if r.type == "ADVISORY"]
+        self.assertIn("https://access.redhat.com/errata/RHSA-2024:1234", urls)
+
+        self.assertIsNotNone(result.database_specific)
+        self.assertEqual(result.database_specific.license, "CC-BY-4.0")
+        self.assertEqual(
+            result.database_specific.license_url,
+            "https://creativecommons.org/licenses/by/4.0/",
+        )
+        self.assertEqual(
+            result.database_specific.source_advisory, "RHSA-2024:1234"
+        )
+
+        self.assertIn("Red Hat", [c.name for c in result.credits])
+
+    def test_no_red_hat_source_omits_attribution(self):
+        """Advisories with no Red Hat source emit no source ref or license block"""
+        result = to_osv_advisory(
+            "https://errata.rockylinux.org", self._advisory(None)
+        )
+
+        self.assertIsNone(result.database_specific)
+        rh_urls = [r.url for r in result.references if "access.redhat.com" in r.url]
+        self.assertEqual(rh_urls, [])
+        self.assertNotIn("Red Hat", [c.name for c in result.credits])
 
 
 if __name__ == "__main__":

--- a/apollo/tests/test_api_updateinfo.py
+++ b/apollo/tests/test_api_updateinfo.py
@@ -50,7 +50,8 @@ def create_mock_advisory(packages, name="RLSA-2024:0001",
                         synopsis="Important: kernel security update",
                         description="An update for kernel is now available.",
                         kind="Security", severity="Important",
-                        topic="An update is available"):
+                        topic="An update is available",
+                        red_hat_advisory_name="RHSA-2024:0001"):
     """Create a mock advisory with packages"""
     advisory = Mock()
     advisory.name = name
@@ -64,6 +65,14 @@ def create_mock_advisory(packages, name="RLSA-2024:0001",
     advisory.packages = packages
     advisory.cves = []
     advisory.fixes = []
+    if red_hat_advisory_name:
+        red_hat_advisory = Mock()
+        red_hat_advisory.name = red_hat_advisory_name
+        advisory.red_hat_advisory = red_hat_advisory
+        advisory.red_hat_advisory_id = 1
+    else:
+        advisory.red_hat_advisory = None
+        advisory.red_hat_advisory_id = None
     return advisory
 
 
@@ -569,6 +578,73 @@ class TestUpdateinfoEndpoints(unittest.TestCase):
         mock_aap.filter.assert_called_once()
         call_args = mock_aap.filter.call_args[1]
         self.assertEqual(call_args["minor_version"], 6)
+
+
+class TestUpdateinfoAttribution(unittest.TestCase):
+    """Test CC BY 4.0 attribution in generated updateinfo.xml"""
+
+    def _generate_tree(self, advisory):
+        affected_product = create_mock_affected_product(advisory)
+        xml_str = generate_updateinfo_xml(
+            affected_products=[affected_product],
+            repo_name="BaseOS",
+            product_arch="x86_64",
+            ui_url="https://errata.rockylinux.org",
+            managing_editor="editor@rockylinux.org",
+            company_name="Rocky Enterprise Software Foundation",
+            supported_product_id=1,
+            product_name_for_packages="Rocky Linux",
+        )
+        return ET.fromstring(xml_str)
+
+    def _advisory_with_pkgs(self, red_hat_advisory_name="RHSA-2024:0001"):
+        packages = [
+            create_mock_package("kernel-4.18.0-425.el8.src.rpm", "kernel", "BaseOS", 1),
+            create_mock_package("kernel-4.18.0-425.el8.x86_64.rpm", "kernel", "BaseOS", 1),
+        ]
+        return create_mock_advisory(
+            packages, red_hat_advisory_name=red_hat_advisory_name
+        )
+
+    def test_rights_includes_red_hat_attribution(self):
+        """<rights> credits the Red Hat source and links the CC BY 4.0 license"""
+        tree = self._generate_tree(self._advisory_with_pkgs())
+        rights = tree.find(".//rights").text
+        self.assertIn("RHSA-2024:0001", rights)
+        self.assertIn("CC BY 4.0", rights)
+        self.assertIn("creativecommons.org/licenses/by/4.0", rights)
+        self.assertIn("with modifications", rights)
+        self.assertIn("©", rights)
+        self.assertNotIn("modified by", rights)
+
+    def test_source_and_license_references_present(self):
+        """A vendor reference to the RHSA and a license reference are emitted"""
+        tree = self._generate_tree(self._advisory_with_pkgs())
+
+        vendor_ref = tree.find(".//reference[@type='vendor']")
+        self.assertIsNotNone(vendor_ref)
+        self.assertEqual(
+            vendor_ref.get("href"),
+            "https://access.redhat.com/errata/RHSA-2024:0001",
+        )
+        self.assertEqual(vendor_ref.get("id"), "RHSA-2024:0001")
+
+        license_ref = tree.find(".//reference[@id='CC-BY-4.0']")
+        self.assertIsNotNone(license_ref)
+        self.assertEqual(
+            license_ref.get("href"),
+            "https://creativecommons.org/licenses/by/4.0/",
+        )
+
+    def test_without_red_hat_source_falls_back_to_plain_copyright(self):
+        """Advisories with no Red Hat source keep a plain copyright and no source refs"""
+        tree = self._generate_tree(
+            self._advisory_with_pkgs(red_hat_advisory_name=None)
+        )
+        rights = tree.find(".//rights").text
+        self.assertIn("Copyright", rights)
+        self.assertNotIn("CC BY 4.0", rights)
+        self.assertIsNone(tree.find(".//reference[@type='vendor']"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Rocky Linux errata advisories (e.g. RLSA-2026:23102) re-publish content from the
corresponding Red Hat advisories — synopsis, description, and topic. Red Hat
licenses that advisory content under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
which permits reuse but requires crediting the source, linking to the original
advisory and to the license, and indicating that changes were made. None of
Apollo's published outputs currently do this. This was raised by a member of the
Rocky community.

## Approach

Attribution text and links are centralized in a new `apollo/server/attribution.py`
and applied to every surface that carries Red Hat-derived text:

- **updateinfo.xml** — the `<rights>` element credits the source advisory under
  CC BY 4.0, plus `<reference>` entries for the source advisory (`type="vendor"`)
  and the license (`type="other"`).
- **v2 and v3 JSON APIs** — a structured `source` object: `name`, `url`,
  `vendor`, `license`, `licenseUrl`.
- **OSV** — a source `ADVISORY` reference, a Red Hat credit, and
  `license`/`license_url`/`source_advisory` in `database_specific`.
- **RSS feed** — the channel copyright carries the CC BY 4.0 notice.
- **Server-rendered advisory page** — an attribution line linking the source
  advisory and the license.

No database migration is required; the source advisory and its URL are derived
from the existing `red_hat_advisory` relation. A plain copyright line is kept as
a fallback for any advisory without a Red Hat source.

## Testing

- New unit tests across updateinfo, OSV, and v2/v3 serialization; all Bazel
  suites pass.
- Validated against a development database with the server running: v2 and v3
  detail + list, OSV, the live `updateinfo.xml` (889 updates in one repo file),
  RSS, and the web advisory page all carry the attribution.
- Verified `dnf` tolerates the new `updateinfo` reference types, both at the
  source level (libsolv/libdnf/libdnf5) and end-to-end via `dnf makecache` on
  Rocky 9.

## Notes

- Companion change in `rocky-linux/errata-frontend` (branch
  `feature/rhel-advisory-attribution`) renders the per-advisory attribution and
  a site-wide footer notice.
- The exact attribution wording is under review; prose may be adjusted.
- No new dependencies.
